### PR TITLE
optimize(packages): ui: optimize components

### DIFF
--- a/packages/ui-variants/src/variants/dropdown-menu.ts
+++ b/packages/ui-variants/src/variants/dropdown-menu.ts
@@ -27,12 +27,13 @@ export const dropdownMenuVariants = tv({
       `relative flex items-center gap-3 rounded-sm outline-none outline-offset-2 transition-colors cursor-pointer select-none`,
       `focus:(bg-accent text-accent-foreground) data-[disabled]:(pointer-events-none opacity-50)`
     ],
-    checkboxItemIndicator: `absolute flex items-center justify-center text-primary`,
+    itemIndicator: `absolute flex items-center justify-center text-primary`,
     radioItem: [
       `relative flex items-center gap-3 rounded-sm outline-none transition-colors cursor-pointer select-none`,
       `focus:(bg-accent text-accent-foreground) data-[disabled]:(pointer-events-none opacity-50)`
     ],
-    radioItemIndicator: `absolute flex items-center justify-center text-primary`,
+    radioIndicatorIconRoot: `size-1.25em flex items-center justify-center`,
+    radioIndicatorIcon: `size-1/2 rounded-full bg-primary`,
     arrow: 'absolute size-8px rotate-45 border-b border-r border-border bg-popover -top-4px rounded-1px'
   },
   variants: {

--- a/packages/ui/src/components/accordion/accordion-content-body.vue
+++ b/packages/ui/src/components/accordion/accordion-content-body.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { Primitive } from 'radix-vue';
 import { accordionVariants, cn } from '@soybean-ui/variants';
 import type { AccordionContentBodyProps } from './types';
@@ -7,13 +8,15 @@ defineOptions({
   name: 'SAccordionContentBody'
 });
 
-const props = defineProps<AccordionContentBodyProps>();
+const { class: cls } = defineProps<AccordionContentBodyProps>();
 
 const { contentBody } = accordionVariants();
+
+const mergedCls = computed(() => cn(contentBody(), cls));
 </script>
 
 <template>
-  <Primitive as="div" :class="cn(contentBody(), props.class)">
+  <Primitive as="div" :class="mergedCls">
     <slot />
   </Primitive>
 </template>

--- a/packages/ui/src/components/accordion/accordion-content.vue
+++ b/packages/ui/src/components/accordion/accordion-content.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { AccordionContent } from 'radix-vue';
 import { accordionVariants, cn } from '@soybean-ui/variants';
 import type { AccordionContentProps } from './types';
@@ -7,13 +8,15 @@ defineOptions({
   name: 'SAccordionContent'
 });
 
-const props = defineProps<AccordionContentProps>();
+const { class: cls } = defineProps<AccordionContentProps>();
 
 const { content } = accordionVariants();
+
+const mergedCls = computed(() => cn(content(), cls));
 </script>
 
 <template>
-  <AccordionContent :class="cn(content(), props.class)">
+  <AccordionContent :class="mergedCls">
     <slot />
   </AccordionContent>
 </template>

--- a/packages/ui/src/components/accordion/accordion-header.vue
+++ b/packages/ui/src/components/accordion/accordion-header.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { AccordionHeader } from 'radix-vue';
 import { accordionVariants, cn } from '@soybean-ui/variants';
 import type { AccordionHeaderProps } from './types';
@@ -7,13 +8,15 @@ defineOptions({
   name: 'SAccordionHeader'
 });
 
-const props = defineProps<AccordionHeaderProps>();
+const { class: cls } = defineProps<AccordionHeaderProps>();
 
 const { header } = accordionVariants();
+
+const mergedCls = computed(() => cn(header(), cls));
 </script>
 
 <template>
-  <AccordionHeader :class="cn(header(), props.class)">
+  <AccordionHeader :class="mergedCls">
     <slot />
   </AccordionHeader>
 </template>

--- a/packages/ui/src/components/accordion/accordion-item.vue
+++ b/packages/ui/src/components/accordion/accordion-item.vue
@@ -1,24 +1,22 @@
 <script setup lang="ts">
-import { AccordionItem, useForwardProps } from 'radix-vue';
+import { computed } from 'vue';
+import { AccordionItem } from 'radix-vue';
 import { accordionVariants, cn } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { AccordionItemProps } from './types';
 
 defineOptions({
   name: 'SAccordionItem'
 });
 
-const props = defineProps<AccordionItemProps>();
-
-const delegatedProps = computedOmit(props, ['class']);
-
-const forwardedProps = useForwardProps(delegatedProps);
+const { class: cls, value, disabled } = defineProps<AccordionItemProps>();
 
 const { item } = accordionVariants();
+
+const mergedCls = computed(() => cn(item(), cls));
 </script>
 
 <template>
-  <AccordionItem v-slot="slotProps" v-bind="forwardedProps" :class="cn(item(), props.class)">
+  <AccordionItem v-slot="slotProps" :class="mergedCls" :value :disabled>
     <slot v-bind="slotProps"></slot>
   </AccordionItem>
 </template>

--- a/packages/ui/src/components/accordion/accordion-trigger.vue
+++ b/packages/ui/src/components/accordion/accordion-trigger.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { AccordionTrigger } from 'radix-vue';
 import { ChevronDown } from 'lucide-vue-next';
 import { accordionVariants, cn } from '@soybean-ui/variants';
@@ -8,16 +9,20 @@ defineOptions({
   name: 'SAccordionTrigger'
 });
 
-const props = defineProps<AccordionTriggerProps>();
+const { class: cls, triggerIconClass } = defineProps<AccordionTriggerProps>();
 
 const { trigger, triggerIcon } = accordionVariants();
+
+const mergedCls = computed(() => cn(trigger(), cls));
+
+const mergedIconCls = computed(() => cn(triggerIcon(), triggerIconClass));
 </script>
 
 <template>
-  <AccordionTrigger :class="cn(trigger(), props.class)">
+  <AccordionTrigger :class="mergedCls">
     <slot />
     <slot name="icon">
-      <ChevronDown :class="cn(triggerIcon())" />
+      <ChevronDown :class="mergedIconCls" />
     </slot>
   </AccordionTrigger>
 </template>

--- a/packages/ui/src/components/accordion/accordion.vue
+++ b/packages/ui/src/components/accordion/accordion.vue
@@ -8,7 +8,6 @@
   "
 >
 import { AccordionRoot, useForwardPropsEmits } from 'radix-vue';
-import type { AccordionRootEmits } from 'radix-vue';
 import { computedOmit } from '../../shared';
 import type { SingleOrMultipleType } from '../../types';
 import SAccordionItem from './accordion-item.vue';
@@ -16,7 +15,7 @@ import SAccordionHeader from './accordion-header.vue';
 import SAccordionTrigger from './accordion-trigger.vue';
 import SAccordionContent from './accordion-content.vue';
 import SAccordionContentBody from './accordion-content-body.vue';
-import type { AccordionItemData, AccordionProps } from './types';
+import type { AccordionEmits, AccordionItemData, AccordionProps } from './types';
 
 defineOptions({
   name: 'SAccordion'
@@ -24,7 +23,7 @@ defineOptions({
 
 const props = defineProps<AccordionProps<T, V, E>>();
 
-const emit = defineEmits<AccordionRootEmits>();
+const emit = defineEmits<AccordionEmits>();
 
 const delegatedProps = computedOmit(props, [
   'items',

--- a/packages/ui/src/components/accordion/types.ts
+++ b/packages/ui/src/components/accordion/types.ts
@@ -1,25 +1,17 @@
-import type { AccordionItemProps as $AccordionItemProps, AccordionRootProps } from 'radix-vue';
-import type { ClassValue, SingleOrMultipleType } from '../../types';
+import type { AccordionRootEmits, AccordionRootProps, AccordionItemProps as _AccordionItemProps } from 'radix-vue';
+import type { ClassValue, ClassValueProp, SingleOrMultipleType } from '../../types';
 
-export type AccordionItemProps = $AccordionItemProps & {
-  class?: ClassValue;
+export type AccordionItemProps = ClassValueProp & Pick<_AccordionItemProps, 'disabled' | 'value'>;
+
+export type AccordionHeaderProps = ClassValueProp;
+
+export type AccordionTriggerProps = ClassValueProp & {
+  triggerIconClass?: ClassValue;
 };
 
-export type AccordionContentProps = {
-  class?: ClassValue;
-};
+export type AccordionContentProps = ClassValueProp;
 
-export type AccordionContentBodyProps = {
-  class?: ClassValue;
-};
-
-export type AccordionHeaderProps = {
-  class?: ClassValue;
-};
-
-export type AccordionTriggerProps = {
-  class?: ClassValue;
-};
+export type AccordionContentBodyProps = ClassValueProp;
 
 export type AccordionItemData = Pick<AccordionItemProps, 'value' | 'disabled'> & {
   title?: string;
@@ -35,8 +27,11 @@ export type AccordionProps<
   itemClass?: ClassValue;
   headerClass?: ClassValue;
   triggerClass?: ClassValue;
+  triggerIconClass?: ClassValue;
   contentClass?: ClassValue;
   contentBodyClass?: ClassValue;
 };
 
-export type { AccordionRootProps };
+export type AccordionEmits = AccordionRootEmits;
+
+export type { AccordionRootProps, AccordionRootEmits };

--- a/packages/ui/src/components/alert-dialog/alert-dialog-action.vue
+++ b/packages/ui/src/components/alert-dialog/alert-dialog-action.vue
@@ -9,12 +9,12 @@ defineOptions({
 
 const props = defineProps<ButtonProps>();
 
-const forwarded = useForwardProps(props);
+const forwardedProps = useForwardProps(props);
 </script>
 
 <template>
   <AlertDialogAction as-child>
-    <SButton v-bind="forwarded">
+    <SButton v-bind="forwardedProps">
       <slot>Confirm</slot>
     </SButton>
   </AlertDialogAction>

--- a/packages/ui/src/components/alert-dialog/alert-dialog-cancel.vue
+++ b/packages/ui/src/components/alert-dialog/alert-dialog-cancel.vue
@@ -9,12 +9,12 @@ defineOptions({
 
 const { variant = 'plain', ...delegatedProps } = defineProps<ButtonProps>();
 
-const forwarded = useForwardProps(delegatedProps);
+const forwardedProps = useForwardProps(delegatedProps);
 </script>
 
 <template>
   <AlertDialogCancel as-child>
-    <SButton v-bind="forwarded" :variant>
+    <SButton v-bind="forwardedProps" :variant>
       <slot>Cancel</slot>
     </SButton>
   </AlertDialogCancel>

--- a/packages/ui/src/components/alert-dialog/alert-dialog-content.vue
+++ b/packages/ui/src/components/alert-dialog/alert-dialog-content.vue
@@ -50,6 +50,10 @@ const slotKeys = computed(() => {
 
   const remainingKeys = allKeys.filter(key => key !== 'default');
 
+  if (!remainingKeys.includes('title-leading')) {
+    remainingKeys.unshift('title-leading');
+  }
+
   return remainingKeys;
 });
 

--- a/packages/ui/src/components/alert-dialog/alert-dialog-overlay.vue
+++ b/packages/ui/src/components/alert-dialog/alert-dialog-overlay.vue
@@ -10,11 +10,9 @@ defineOptions({
 
 const { class: cls, forceMount } = defineProps<AlertDialogOverlayProps>();
 
-const mergedCls = computed(() => {
-  const { overlay } = dialogVariants();
+const { overlay } = dialogVariants();
 
-  return cn(overlay(), cls);
-});
+const mergedCls = computed(() => cn(overlay(), cls));
 </script>
 
 <template>

--- a/packages/ui/src/components/alert-dialog/alert-dialog.vue
+++ b/packages/ui/src/components/alert-dialog/alert-dialog.vue
@@ -62,7 +62,7 @@ const cardSlotKeys = Object.keys(slots).filter(slot => slot !== 'trigger') as (k
     <AlertDialogTrigger as-child>
       <slot name="trigger" />
     </AlertDialogTrigger>
-    <AlertDialogPortal :to="to" :disabled="disabledPortal" :force-mount="forceMountPortal">
+    <AlertDialogPortal :to :disabled="disabledPortal" :force-mount="forceMountPortal">
       <SAlertDialogOverlay :force-mount="forceMountOverlay" :class="overlayClass" />
       <SAlertDialogContent v-bind="forwardedContent">
         <template v-for="slotKey in cardSlotKeys" :key="slotKey" #[slotKey]>

--- a/packages/ui/src/components/alert-dialog/types.ts
+++ b/packages/ui/src/components/alert-dialog/types.ts
@@ -1,28 +1,25 @@
 import type {
-  AlertDialogContentProps as $AlertDialogContentProps,
-  AlertDialogEmits as $AlertDialogEmits,
-  AlertDialogOverlayProps as $AlertDialogOverlayProps,
   AlertDialogContentEmits,
   AlertDialogPortalProps,
-  AlertDialogProps as AlertDialogRootProps
+  AlertDialogContentProps as _AlertDialogContentProps,
+  AlertDialogEmits as _AlertDialogEmits,
+  AlertDialogOverlayProps as _AlertDialogOverlayProps,
+  AlertDialogProps as _AlertDialogProps
 } from 'radix-vue';
 import type { ThemeColor } from '@soybean-ui/variants';
-import type { ClassValue } from '../../types';
+import type { ClassValue, ClassValueProp } from '../../types';
 import type { CardProps } from '../card/types';
 
-export type AlertDialogOverlayProps = Pick<$AlertDialogOverlayProps, 'forceMount'> & {
-  class?: ClassValue;
-};
+export type AlertDialogOverlayProps = ClassValueProp & Pick<_AlertDialogOverlayProps, 'forceMount'>;
 
 export type AlertType = Extract<ThemeColor, 'destructive' | 'success' | 'warning' | 'info'>;
 
-export type AlertDialogContentProps = Pick<
-  $AlertDialogContentProps,
-  'forceMount' | 'trapFocus' | 'disableOutsidePointerEvents'
-> &
-  CardProps & {
+export type AlertDialogContentProps = CardProps &
+  Pick<_AlertDialogContentProps, 'forceMount' | 'trapFocus' | 'disableOutsidePointerEvents'> & {
     type?: AlertType;
   };
+
+export type AlertDialogRootProps = Pick<_AlertDialogProps, 'open' | 'defaultOpen'>;
 
 export type AlertDialogProps = AlertDialogRootProps &
   AlertDialogContentProps &
@@ -33,8 +30,8 @@ export type AlertDialogProps = AlertDialogRootProps &
     forceMountOverlay?: boolean;
   };
 
-export type AlertDialogRootEmits = $AlertDialogEmits;
+export type AlertDialogRootEmits = _AlertDialogEmits;
 
 export type AlertDialogEmits = AlertDialogRootEmits & AlertDialogContentEmits;
 
-export type { AlertDialogRootProps, AlertDialogPortalProps, AlertDialogContentEmits };
+export type { AlertDialogPortalProps, AlertDialogContentEmits };

--- a/packages/ui/src/components/alert/alert-description.vue
+++ b/packages/ui/src/components/alert/alert-description.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { Primitive } from 'radix-vue';
 import { alertVariants, cn } from '@soybean-ui/variants';
 import type { AlertDescriptionProps } from './types';
@@ -7,13 +8,15 @@ defineOptions({
   name: 'SAlertDescription'
 });
 
-const props = defineProps<AlertDescriptionProps>();
+const { class: cls } = defineProps<AlertDescriptionProps>();
 
 const { description } = alertVariants();
+
+const mergedCls = computed(() => cn(description(), cls));
 </script>
 
 <template>
-  <Primitive as="div" :class="cn(description(), props.class)">
+  <Primitive as="div" :class="mergedCls">
     <slot />
   </Primitive>
 </template>

--- a/packages/ui/src/components/alert/alert-header.vue
+++ b/packages/ui/src/components/alert/alert-header.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { Primitive } from 'radix-vue';
 import { alertVariants, cn } from '@soybean-ui/variants';
 import type { AlertHeaderProps } from './types';
@@ -7,13 +8,15 @@ defineOptions({
   name: 'SAlertHeader'
 });
 
-const props = defineProps<AlertHeaderProps>();
+const { class: cls } = defineProps<AlertHeaderProps>();
 
 const { header } = alertVariants();
+
+const mergedCls = computed(() => cn(header(), cls));
 </script>
 
 <template>
-  <Primitive as="div" :class="cn(header(), props.class)" role="alert">
+  <Primitive as="div" role="alert" :class="mergedCls">
     <slot />
   </Primitive>
 </template>

--- a/packages/ui/src/components/alert/alert-root.vue
+++ b/packages/ui/src/components/alert/alert-root.vue
@@ -8,19 +8,17 @@ defineOptions({
   name: 'SAlertRoot'
 });
 
-const props = defineProps<AlertRootProps>();
+const { class: cls, color, variant } = defineProps<AlertRootProps>();
 
-const cls = computed(() => {
-  const { color, variant } = props;
-
+const mergedCls = computed(() => {
   const { root } = alertVariants({ color, variant });
 
-  return cn(root(), props.class);
+  return cn(root(), cls);
 });
 </script>
 
 <template>
-  <Primitive as="div" :class="cls" role="alert">
+  <Primitive as="div" :class="mergedCls" role="alert">
     <slot />
   </Primitive>
 </template>

--- a/packages/ui/src/components/alert/alert-title-root.vue
+++ b/packages/ui/src/components/alert/alert-title-root.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { Primitive } from 'radix-vue';
 import { alertVariants, cn } from '@soybean-ui/variants';
 import type { AlertTitleRootProps } from './types';
@@ -7,13 +8,17 @@ defineOptions({
   name: 'SAlertTitleRoot'
 });
 
-const props = defineProps<AlertTitleRootProps>();
+const { class: cls, color } = defineProps<AlertTitleRootProps>();
 
-const { titleRoot } = alertVariants();
+const mergedCls = computed(() => {
+  const { titleRoot } = alertVariants({ color });
+
+  return cn(titleRoot(), cls);
+});
 </script>
 
 <template>
-  <Primitive as="div" :class="cn(titleRoot(), props.class)">
+  <Primitive as="div" :class="mergedCls">
     <slot />
   </Primitive>
 </template>

--- a/packages/ui/src/components/alert/alert-title.vue
+++ b/packages/ui/src/components/alert/alert-title.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { Primitive } from 'radix-vue';
 import { alertVariants, cn } from '@soybean-ui/variants';
 import type { AlertTitleProps } from './types';
@@ -7,13 +8,15 @@ defineOptions({
   name: 'SAlertTitle'
 });
 
-const props = defineProps<AlertTitleProps>();
+const { class: cls } = defineProps<AlertTitleProps>();
 
 const { title } = alertVariants();
+
+const mergedCls = computed(() => cn(title(), cls));
 </script>
 
 <template>
-  <Primitive as="h5" :class="cn(title(), props.class)">
+  <Primitive as="h5" :class="mergedCls">
     <slot />
   </Primitive>
 </template>

--- a/packages/ui/src/components/alert/alert.vue
+++ b/packages/ui/src/components/alert/alert.vue
@@ -1,9 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue';
-import { useForwardProps } from 'radix-vue';
-import { alertVariants, cn } from '@soybean-ui/variants';
 import { X } from 'lucide-vue-next';
-import { computedPick } from '../../shared';
 import SButtonIcon from '../button/button-icon.vue';
 import SAlertRoot from './alert-root.vue';
 import SAlertHeader from './alert-header.vue';
@@ -16,17 +12,9 @@ defineOptions({
   name: 'SAlert'
 });
 
-const props = defineProps<AlertProps>();
+const { class: rootCls, color, variant } = defineProps<AlertProps>();
 
 const close = defineModel<boolean>('close', { default: false });
-
-const delegatedProps = computedPick(props, ['color', 'variant', 'class']);
-
-const forwarded = useForwardProps(delegatedProps);
-
-const { titleRoot } = alertVariants();
-
-const titleRootCls = computed(() => cn(titleRoot({ color: props.color }), props.titleRootClass));
 
 function closeAlert() {
   close.value = true;
@@ -34,15 +22,15 @@ function closeAlert() {
 </script>
 
 <template>
-  <SAlertRoot v-show="!close" v-bind="forwarded">
+  <SAlertRoot v-show="!close" :class="rootCls" :color :variant>
     <SAlertHeader :class="headerClass">
-      <SAlertTitleRoot :class="titleRootCls">
+      <SAlertTitleRoot :class="titleRootClass" :color>
         <slot name="icon" />
         <SAlertTitle :class="titleClass">
           <slot>{{ title }}</slot>
         </SAlertTitle>
       </SAlertTitleRoot>
-      <slot name="extra" :closable="closable">
+      <slot name="extra" :closable>
         <SButtonIcon v-if="closable" size="xs" fit-content @click="closeAlert">
           <X />
         </SButtonIcon>

--- a/packages/ui/src/components/alert/types.ts
+++ b/packages/ui/src/components/alert/types.ts
@@ -1,29 +1,22 @@
 import type { AlertVariant, ThemeColor } from '@soybean-ui/variants';
-import type { ClassValue } from '../../types';
+import type { ClassValue, ClassValueProp } from '../../types';
 
-export interface AlertRootProps {
-  class?: ClassValue;
+export type AlertRootProps = ClassValueProp & {
   color?: ThemeColor;
   variant?: AlertVariant;
-}
-
-export type AlertHeaderProps = {
-  class?: ClassValue;
 };
 
-export type AlertTitleRootProps = {
-  class?: ClassValue;
+export type AlertHeaderProps = ClassValueProp;
+
+export type AlertTitleRootProps = ClassValueProp & {
+  color?: ThemeColor;
 };
 
-export type AlertTitleProps = {
-  class?: ClassValue;
-};
+export type AlertTitleProps = ClassValueProp;
 
-export type AlertDescriptionProps = {
-  class?: ClassValue;
-};
+export type AlertDescriptionProps = ClassValueProp;
 
-export interface AlertProps extends AlertRootProps {
+export type AlertProps = AlertRootProps & {
   title?: string;
   headerClass?: ClassValue;
   titleRootClass?: ClassValue;
@@ -32,6 +25,6 @@ export interface AlertProps extends AlertRootProps {
   descriptionClass?: ClassValue;
   closable?: boolean;
   close?: boolean;
-}
+};
 
 export type { AlertVariant };

--- a/packages/ui/src/components/aspect-ratio/aspect-ratio.vue
+++ b/packages/ui/src/components/aspect-ratio/aspect-ratio.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { AspectRatio } from 'radix-vue';
+import { AspectRatio, useForwardProps } from 'radix-vue';
 import type { AspectRatioProps } from './types';
 
 defineOptions({
@@ -7,10 +7,12 @@ defineOptions({
 });
 
 const props = defineProps<AspectRatioProps>();
+
+const forwardedProps = useForwardProps(props);
 </script>
 
 <template>
-  <AspectRatio v-bind="props">
+  <AspectRatio v-bind="forwardedProps">
     <slot />
   </AspectRatio>
 </template>

--- a/packages/ui/src/components/aspect-ratio/types.ts
+++ b/packages/ui/src/components/aspect-ratio/types.ts
@@ -1,3 +1,4 @@
-import type { AspectRatioProps } from 'radix-vue';
+import type { AspectRatioProps as _AspectRatioProps } from 'radix-vue';
+import type { ClassValueProp } from '../../types';
 
-export type { AspectRatioProps };
+export type AspectRatioProps = ClassValueProp & Pick<_AspectRatioProps, 'ratio'>;

--- a/packages/ui/src/components/avatar/avatar-fallback.vue
+++ b/packages/ui/src/components/avatar/avatar-fallback.vue
@@ -1,24 +1,22 @@
 <script setup lang="ts">
-import { AvatarFallback, useForwardProps } from 'radix-vue';
+import { computed } from 'vue';
+import { AvatarFallback } from 'radix-vue';
 import { avatarVariants, cn } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { AvatarFallbackProps } from './types';
 
 defineOptions({
   name: 'SAvatarFallback'
 });
 
-const props = defineProps<AvatarFallbackProps>();
-
-const delegatedProps = computedOmit(props, ['class']);
-
-const forwardedProps = useForwardProps(delegatedProps);
+const { class: cls, delayMs } = defineProps<AvatarFallbackProps>();
 
 const { fallback } = avatarVariants();
+
+const mergedCls = computed(() => cn(fallback(), cls));
 </script>
 
 <template>
-  <AvatarFallback v-bind="forwardedProps" :class="cn(fallback(), props.class)">
+  <AvatarFallback :delay-ms :class="mergedCls">
     <slot></slot>
   </AvatarFallback>
 </template>

--- a/packages/ui/src/components/avatar/avatar-image.vue
+++ b/packages/ui/src/components/avatar/avatar-image.vue
@@ -1,27 +1,24 @@
 <script setup lang="ts">
-import { AvatarImage, useForwardPropsEmits } from 'radix-vue';
-import type { AvatarImageEmits } from 'radix-vue';
+import { computed } from 'vue';
+import { AvatarImage } from 'radix-vue';
 import { avatarVariants, cn } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
-import type { AvatarImageProps } from './types';
+import type { AvatarImageEmits, AvatarImageProps } from './types';
 
 defineOptions({
   name: 'SAvatarImage'
 });
 
-const props = defineProps<AvatarImageProps>();
-
-const delegatedProps = computedOmit(props, ['class']);
+const { class: cls, src, alt } = defineProps<AvatarImageProps>();
 
 const emit = defineEmits<AvatarImageEmits>();
 
-const forwarded = useForwardPropsEmits(delegatedProps, emit);
-
 const { image } = avatarVariants();
+
+const mergedCls = computed(() => cn(image(), cls));
 </script>
 
 <template>
-  <AvatarImage v-bind="forwarded" :class="cn(image(), props.class)" />
+  <AvatarImage :src :alt :class="mergedCls" @loading-status-change="emit('loadingStatusChange', $event)" />
 </template>
 
 <style scoped></style>

--- a/packages/ui/src/components/avatar/avatar-root.vue
+++ b/packages/ui/src/components/avatar/avatar-root.vue
@@ -8,17 +8,17 @@ defineOptions({
   name: 'SAvatarRoot'
 });
 
-const props = defineProps<AvatarRootProps>();
+const { class: cls, size } = defineProps<AvatarRootProps>();
 
-const cls = computed(() => {
-  const { root } = avatarVariants({ size: props.size });
+const mergedCls = computed(() => {
+  const { root } = avatarVariants({ size });
 
-  return cn(root(), props.class);
+  return cn(root(), cls);
 });
 </script>
 
 <template>
-  <AvatarRoot :as="as" :as-child="asChild" :class="cls">
+  <AvatarRoot :class="mergedCls">
     <slot />
   </AvatarRoot>
 </template>

--- a/packages/ui/src/components/avatar/avatar.vue
+++ b/packages/ui/src/components/avatar/avatar.vue
@@ -1,27 +1,29 @@
 <script setup lang="ts">
-import { useEmitAsProps } from 'radix-vue';
-import type { AvatarImageEmits } from 'radix-vue';
 import SAvatarRoot from './avatar-root.vue';
 import SAvatarImage from './avatar-image.vue';
 import SAvatarFallback from './avatar-fallback.vue';
-import type { AvatarProps } from './types';
+import type { AvatarEmits, AvatarProps } from './types';
 
 defineOptions({
   name: 'SAvatar'
 });
 
-const props = defineProps<AvatarProps>();
+const { class: rootClass } = defineProps<AvatarProps>();
 
-const emit = defineEmits<AvatarImageEmits>();
-
-const emitAsProps = useEmitAsProps(emit);
+const emit = defineEmits<AvatarEmits>();
 </script>
 
 <template>
-  <SAvatarRoot :as="as" :as-child="asChild" :size="size" :class="props.class">
+  <SAvatarRoot :size :class="rootClass">
     <slot>
       <slot name="image">
-        <SAvatarImage :class="imageClass" :src="src" :alt="alt" :delay-ms="delayMs" v-bind="emitAsProps" />
+        <SAvatarImage
+          :class="imageClass"
+          :src
+          :alt
+          :delay-ms
+          @loading-status-change="emit('loadingStatusChange', $event)"
+        />
       </slot>
       <SAvatarFallback :class="fallbackClass">
         <slot name="fallback">{{ fallbackLabel }}</slot>

--- a/packages/ui/src/components/avatar/types.ts
+++ b/packages/ui/src/components/avatar/types.ts
@@ -1,29 +1,30 @@
 import type {
-  AvatarFallbackProps as $AvatarFallbackProps,
-  AvatarImageProps as $AvatarImageProps,
-  AvatarRootProps as $AvatarRootProps
+  AvatarImageEmits,
+  AvatarFallbackProps as _AvatarFallbackProps,
+  AvatarImageProps as _AvatarImageProps
 } from 'radix-vue';
 import type { ThemeSize } from '@soybean-ui/variants';
-import type { ClassValue } from '../../types';
+import type { ClassValue, ClassValueProp } from '../../types';
 
-export type AvatarRootProps = $AvatarRootProps & {
-  class?: ClassValue;
+export type AvatarRootProps = ClassValueProp & {
   size?: ThemeSize;
 };
 
-export type AvatarImageProps = $AvatarImageProps & {
-  class?: ClassValue;
-  alt?: string;
-};
+export type AvatarImageProps = ClassValueProp &
+  Pick<_AvatarImageProps, 'src'> & {
+    alt?: string;
+  };
 
-export type AvatarFallbackProps = $AvatarFallbackProps & {
-  class?: ClassValue;
-};
+export type AvatarFallbackProps = ClassValueProp & Pick<_AvatarFallbackProps, 'delayMs'>;
 
 export type AvatarProps = AvatarRootProps &
-  Pick<AvatarImageProps, 'src' | 'alt'> &
-  Pick<AvatarFallbackProps, 'delayMs'> & {
+  AvatarImageProps &
+  AvatarFallbackProps & {
     imageClass?: ClassValue;
     fallbackLabel?: string;
     fallbackClass?: ClassValue;
   };
+
+export type AvatarEmits = AvatarImageEmits;
+
+export type { AvatarImageEmits };

--- a/packages/ui/src/components/badge/badge.vue
+++ b/packages/ui/src/components/badge/badge.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { Primitive } from 'radix-vue';
 import { badgeVariants, cn } from '@soybean-ui/variants';
 import { X } from 'lucide-vue-next';
@@ -9,7 +10,11 @@ defineOptions({
   name: 'SBadge'
 });
 
-const props = defineProps<BadgeProps>();
+const { class: cls, closeClass, color, variant } = defineProps<BadgeProps>();
+
+const mergedCls = computed(() => cn(badgeVariants({ color, variant }), cls));
+
+const mergedCloseCls = computed(() => cn('border-0 bg-transparent -mr-1.5', closeClass));
 
 const close = defineModel<boolean>('close', {
   default: false
@@ -21,18 +26,10 @@ function closeAlert() {
 </script>
 
 <template>
-  <Primitive v-show="!close" as="div" :class="cn(badgeVariants({ color, variant }), props.class)">
+  <Primitive v-show="!close" as="div" :class="mergedCls">
     <slot />
     <slot name="trailing" :close-alert="closeAlert">
-      <SButtonIcon
-        v-if="closable"
-        :color="color"
-        :variant="variant"
-        size="xs"
-        fit-content
-        :class="cn('border-0 bg-transparent -mr-1.5', closeClass)"
-        @click="closeAlert"
-      >
+      <SButtonIcon v-if="closable" :color :variant size="xs" fit-content :class="mergedCloseCls" @click="closeAlert">
         <X />
       </SButtonIcon>
     </slot>

--- a/packages/ui/src/components/badge/types.ts
+++ b/packages/ui/src/components/badge/types.ts
@@ -1,8 +1,7 @@
 import type { BadgeVariant, ThemeColor } from '@soybean-ui/variants';
-import type { ClassValue } from '../../types';
+import type { ClassValue, ClassValueProp } from '../../types';
 
-export type BadgeProps = {
-  class?: ClassValue;
+export type BadgeProps = ClassValueProp & {
   color?: ThemeColor;
   variant?: BadgeVariant;
   closable?: boolean;

--- a/packages/ui/src/components/button/button-group.vue
+++ b/packages/ui/src/components/button/button-group.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { Primitive } from 'radix-vue';
 import { buttonGroupVariants, cn } from '@soybean-ui/variants';
 import type { ButtonGroupProps } from './types';
@@ -7,11 +8,13 @@ defineOptions({
   name: 'SButtonGroup'
 });
 
-const props = defineProps<ButtonGroupProps>();
+const { class: cls, orientation } = defineProps<ButtonGroupProps>();
+
+const mergedCls = computed(() => cn(buttonGroupVariants({ orientation }), cls));
 </script>
 
 <template>
-  <Primitive as="div" :class="cn(buttonGroupVariants({ orientation }), props.class)">
+  <Primitive as="div" :class="mergedCls">
     <slot />
   </Primitive>
 </template>

--- a/packages/ui/src/components/button/button-icon.vue
+++ b/packages/ui/src/components/button/button-icon.vue
@@ -7,17 +7,13 @@ defineOptions({
   name: 'SButtonIcon'
 });
 
-const props = withDefaults(defineProps<ButtonProps>(), {
-  color: 'accent',
-  variant: 'ghost',
-  shape: 'square'
-});
+const { color = 'accent', variant = 'ghost', shape = 'square', ...delegatedProps } = defineProps<ButtonProps>();
 
-const forwarded = useForwardProps(props);
+const forwardedProps = useForwardProps(delegatedProps);
 </script>
 
 <template>
-  <SButton v-bind="forwarded">
+  <SButton v-bind="forwardedProps" :color :variant :shape>
     <slot></slot>
   </SButton>
 </template>

--- a/packages/ui/src/components/button/button.vue
+++ b/packages/ui/src/components/button/button.vue
@@ -1,25 +1,22 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { useForwardProps } from 'radix-vue';
 import { buttonVariants, cn } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { ButtonProps } from './types';
 
 defineOptions({
   name: 'SButton'
 });
 
-const props = defineProps<ButtonProps>();
-
-const delegatedProps = computedOmit(props, ['class', 'color', 'variant', 'size', 'shape', 'fitContent', 'shadow']);
+const { class: cls, color, variant, size, shape, shadow, fitContent, ...delegatedProps } = defineProps<ButtonProps>();
 
 const forwardedProps = useForwardProps(delegatedProps);
+
+const mergedCls = computed(() => cn(buttonVariants({ color, variant, size, shape, shadow, fitContent }), cls));
 </script>
 
 <template>
-  <button
-    v-bind="forwardedProps"
-    :class="cn(buttonVariants({ color, variant, size, shape, shadow, fitContent }), props.class)"
-  >
+  <button v-bind="forwardedProps" :class="mergedCls">
     <slot name="leading" />
     <slot />
     <slot name="trailing" />

--- a/packages/ui/src/components/button/loading-button.vue
+++ b/packages/ui/src/components/button/loading-button.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { useForwardProps } from 'radix-vue';
 import { LoaderCircle } from 'lucide-vue-next';
-import { computed } from 'vue';
-import { computedOmit } from '../../shared';
 import type { LoadingButtonProps } from './types';
 import SButton from './button.vue';
 
@@ -10,17 +9,15 @@ defineOptions({
   name: 'SLoadingButton'
 });
 
-const props = defineProps<LoadingButtonProps>();
+const { disabled, loading, ...delegatedProps } = defineProps<LoadingButtonProps>();
 
-const delegatedProps = computedOmit(props, ['disabled', 'loading']);
+const forwardedProps = useForwardProps(delegatedProps);
 
-const forwarded = useForwardProps(delegatedProps);
-
-const disabled = computed(() => props.loading || props.disabled);
+const isDisabled = computed(() => loading || disabled);
 </script>
 
 <template>
-  <SButton v-bind="forwarded" :disabled="disabled">
+  <SButton v-bind="forwardedProps" :disabled="isDisabled">
     <template #leading>
       <slot v-if="loading" name="loading">
         <LoaderCircle class="animate-spin" />

--- a/packages/ui/src/components/button/types.ts
+++ b/packages/ui/src/components/button/types.ts
@@ -6,10 +6,9 @@ import type {
   ThemeOrientation,
   ThemeSize
 } from '@soybean-ui/variants';
-import type { ClassValue } from '../../types';
+import type { ClassValueProp } from '../../types';
 
-export type ButtonProps = {
-  class?: ClassValue;
+export type ButtonProps = ClassValueProp & {
   color?: ThemeColor;
   variant?: ButtonVariant;
   size?: ThemeSize;
@@ -26,16 +25,17 @@ export type ButtonProps = {
   formnovalidate?: boolean;
   formtarget?: string;
   name?: string;
-  type?: 'submit' | 'reset' | 'button';
+  type?: ButtonType;
   value?: string | ReadonlyArray<string> | number;
 };
+
+export type ButtonType = 'submit' | 'reset' | 'button';
 
 export type LoadingButtonProps = ButtonProps & {
   loading?: boolean;
 };
 
-export type ButtonGroupProps = {
-  class?: ClassValue;
+export type ButtonGroupProps = ClassValueProp & {
   orientation?: ThemeOrientation;
 };
 

--- a/packages/ui/src/components/card/card-content.vue
+++ b/packages/ui/src/components/card/card-content.vue
@@ -8,17 +8,17 @@ defineOptions({
   name: 'SCardContent'
 });
 
-const props = defineProps<CardContentProps>();
+const { class: cls, size } = defineProps<CardContentProps>();
 
-const cls = computed(() => {
-  const { content } = cardVariants({ size: props.size });
+const mergedCls = computed(() => {
+  const { content } = cardVariants({ size });
 
-  return cn(content(), props.class);
+  return cn(content(), cls);
 });
 </script>
 
 <template>
-  <Primitive as="div" :class="cls">
+  <Primitive as="div" :class="mergedCls">
     <slot />
   </Primitive>
 </template>

--- a/packages/ui/src/components/card/card-footer.vue
+++ b/packages/ui/src/components/card/card-footer.vue
@@ -9,19 +9,19 @@ defineOptions({
   name: 'SCardFooter'
 });
 
-const props = defineProps<CardFooterProps>();
+const { class: cls, size, split } = defineProps<CardFooterProps>();
 
-const cls = computed(() => {
-  const split: CardSplit = props.split ? 'footer' : 'none';
+const mergedCls = computed(() => {
+  const footerSplit: CardSplit = split ? 'footer' : 'none';
 
-  const { footer } = cardVariants({ size: props.size, split });
+  const { footer } = cardVariants({ size, split: footerSplit });
 
-  return cn(footer(), props.class);
+  return cn(footer(), cls);
 });
 </script>
 
 <template>
-  <Primitive as="div" :class="cls">
+  <Primitive as="div" :class="mergedCls">
     <slot />
   </Primitive>
 </template>

--- a/packages/ui/src/components/card/card-header.vue
+++ b/packages/ui/src/components/card/card-header.vue
@@ -9,19 +9,19 @@ defineOptions({
   name: 'SCardHeader'
 });
 
-const props = defineProps<CardHeaderProps>();
+const { class: cls, size, split } = defineProps<CardHeaderProps>();
 
-const cls = computed(() => {
-  const split: CardSplit = props.split ? 'header' : 'none';
+const mergedCls = computed(() => {
+  const headerSplit: CardSplit = split ? 'header' : 'none';
 
-  const { header } = cardVariants({ size: props.size, split });
+  const { header } = cardVariants({ size, split: headerSplit });
 
-  return cn(header(), props.class);
+  return cn(header(), cls);
 });
 </script>
 
 <template>
-  <Primitive as="div" :class="cls">
+  <Primitive as="div" :class="mergedCls">
     <slot />
   </Primitive>
 </template>

--- a/packages/ui/src/components/card/card-root.vue
+++ b/packages/ui/src/components/card/card-root.vue
@@ -8,17 +8,17 @@ defineOptions({
   name: 'SCardRoot'
 });
 
-const props = defineProps<CardRootProps>();
+const { class: cls, size } = defineProps<CardRootProps>();
 
-const cls = computed(() => {
-  const { root } = cardVariants({ size: props.size });
+const mergedCls = computed(() => {
+  const { root } = cardVariants({ size });
 
-  return cn(root(), props.class);
+  return cn(root(), cls);
 });
 </script>
 
 <template>
-  <Primitive as="div" :class="cls">
+  <Primitive as="div" :class="mergedCls">
     <slot />
   </Primitive>
 </template>

--- a/packages/ui/src/components/card/card-title-root.vue
+++ b/packages/ui/src/components/card/card-title-root.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { Primitive } from 'radix-vue';
 import { cardVariants, cn } from '@soybean-ui/variants';
 import type { CardTitleRootProps } from './types';
@@ -7,13 +8,15 @@ defineOptions({
   name: 'SCardTitleRoot'
 });
 
-const props = defineProps<CardTitleRootProps>();
+const { class: cls } = defineProps<CardTitleRootProps>();
 
 const { titleRoot } = cardVariants();
+
+const mergedCls = computed(() => cn(titleRoot(), cls));
 </script>
 
 <template>
-  <Primitive as="div" :class="cn(titleRoot(), props.class)">
+  <Primitive as="div" :class="mergedCls">
     <slot name="leading" />
     <slot />
     <slot name="trailing" />

--- a/packages/ui/src/components/card/card-title.vue
+++ b/packages/ui/src/components/card/card-title.vue
@@ -8,17 +8,17 @@ defineOptions({
   name: 'SCardTitle'
 });
 
-const props = defineProps<CardTitleProps>();
+const { class: cls, size } = defineProps<CardTitleProps>();
 
-const cls = computed(() => {
-  const { title } = cardVariants({ size: props.size });
+const mergedCls = computed(() => {
+  const { title } = cardVariants({ size });
 
-  return cn(title(), props.class);
+  return cn(title(), cls);
 });
 </script>
 
 <template>
-  <Primitive as="div" :class="cls">
+  <Primitive as="div" :class="mergedCls">
     <slot />
   </Primitive>
 </template>

--- a/packages/ui/src/components/card/card.vue
+++ b/packages/ui/src/components/card/card.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { useForwardProps } from 'radix-vue';
 import { cardVariants, cn } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import SCardRoot from './card-root.vue';
 import SCardHeader from './card-header.vue';
 import SCardTitleRoot from './card-title-root.vue';
@@ -15,10 +13,17 @@ defineOptions({
   name: 'SCard'
 });
 
-const props = withDefaults(defineProps<CardProps>(), {
-  size: 'md',
-  split: 'none'
-});
+const {
+  class: rootCls,
+  size,
+  split,
+  title,
+  headerClass,
+  titleClass,
+  titleRootClass,
+  contentClass,
+  footerClass
+} = defineProps<CardProps>();
 
 type Slots = {
   default: () => any;
@@ -33,34 +38,22 @@ type Slots = {
 
 const slots = defineSlots<Slots>();
 
-const delegatedProps = computedOmit(props, [
-  'title',
-  'split',
-  'headerClass',
-  'titleClass',
-  'titleRootClass',
-  'contentClass',
-  'footerClass'
-]);
-
-const forwardedProps = useForwardProps(delegatedProps);
-
 const showHeader = computed(() => {
-  return Boolean(slots.header || slots.title || props.title || slots.extra);
+  return Boolean(slots.header || slots.title || title || slots.extra);
 });
 
-const headerSplit = computed(() => props.split === 'header' || props.split === 'all');
+const headerSplit = computed(() => split === 'header' || split === 'all');
 
 const showFooter = computed(() => Boolean(slots.footer));
 
-const footerSplit = computed(() => props.split === 'footer' || props.split === 'all');
+const footerSplit = computed(() => split === 'footer' || split === 'all');
 
 const contentCls = computed(() => {
-  const split = getSplit(props.split, showHeader.value, showFooter.value);
+  const contentSplit = getSplit(split, showHeader.value, showFooter.value);
 
-  const { content } = cardVariants({ size: props.size, split });
+  const { content } = cardVariants({ size, split: contentSplit });
 
-  return cn(content(), props.contentClass);
+  return cn(content(), contentClass);
 });
 
 function getSplit(initSplit?: CardSplit, headerVisible?: boolean, footerVisible?: boolean) {
@@ -85,13 +78,13 @@ function getSplit(initSplit?: CardSplit, headerVisible?: boolean, footerVisible?
 </script>
 
 <template>
-  <SCardRoot v-bind="forwardedProps">
-    <SCardHeader v-if="showHeader" :size="size" :split="headerSplit" :class="headerClass">
+  <SCardRoot :class="rootCls" :size>
+    <SCardHeader v-if="showHeader" :class="headerClass" :size :split="headerSplit">
       <slot name="header">
         <slot name="title-root">
           <SCardTitleRoot :class="titleRootClass">
             <slot name="title-leading" />
-            <SCardTitle :size="size" :class="titleClass">
+            <SCardTitle :class="titleClass" :size>
               <slot name="title">{{ title }}</slot>
             </SCardTitle>
             <slot name="title-trailing" />
@@ -100,10 +93,10 @@ function getSplit(initSplit?: CardSplit, headerVisible?: boolean, footerVisible?
         <slot name="extra"></slot>
       </slot>
     </SCardHeader>
-    <SCardContent :size="size" :class="contentCls">
+    <SCardContent :class="contentCls" :size>
       <slot />
     </SCardContent>
-    <SCardFooter v-if="showFooter" :size="size" :split="footerSplit" :class="footerClass">
+    <SCardFooter v-if="showFooter" :class="footerClass" :size :split="footerSplit">
       <slot name="footer"></slot>
     </SCardFooter>
   </SCardRoot>

--- a/packages/ui/src/components/card/index.ts
+++ b/packages/ui/src/components/card/index.ts
@@ -1,11 +1,11 @@
-import SCard from './card.vue';
 import SCardRoot from './card-root.vue';
 import SCardHeader from './card-header.vue';
 import SCardTitleRoot from './card-title-root.vue';
 import SCardTitle from './card-title.vue';
 import SCardContent from './card-content.vue';
 import SCardFooter from './card-footer.vue';
+import SCard from './card.vue';
 
-export { SCard, SCardRoot, SCardHeader, SCardTitleRoot, SCardTitle, SCardContent, SCardFooter };
+export { SCardRoot, SCardHeader, SCardTitleRoot, SCardTitle, SCardContent, SCardFooter, SCard };
 
 export * from './types';

--- a/packages/ui/src/components/card/types.ts
+++ b/packages/ui/src/components/card/types.ts
@@ -1,36 +1,27 @@
-import type { CardSplit as $CardSplit, ThemeSize } from '@soybean-ui/variants';
-import type { ClassValue } from '../../types';
+import type { CardSplit, ThemeSize } from '@soybean-ui/variants';
+import type { ClassValue, ClassValueProp } from '../../types';
 
-export type CardRootProps = {
-  class?: ClassValue;
+export type CardRootProps = ClassValueProp & {
   size?: ThemeSize;
 };
 
-export type CardSplit = $CardSplit;
-
-export type CardHeaderProps = {
-  class?: ClassValue;
+export type CardHeaderProps = ClassValueProp & {
   size?: ThemeSize;
   /** show a divider between the header and the content */
   split?: boolean;
 };
 
-export type CardTitleRootProps = {
-  class?: ClassValue;
-};
+export type CardTitleRootProps = ClassValueProp;
 
-export type CardTitleProps = {
-  class?: ClassValue;
+export type CardTitleProps = ClassValueProp & {
   size?: ThemeSize;
 };
 
-export type CardContentProps = {
-  class?: ClassValue;
+export type CardContentProps = ClassValueProp & {
   size?: ThemeSize;
 };
 
-export type CardFooterProps = {
-  class?: ClassValue;
+export type CardFooterProps = ClassValueProp & {
   size?: ThemeSize;
   /** show a divider between the footer and the content */
   split?: boolean;
@@ -45,3 +36,5 @@ export type CardProps = CardRootProps & {
   contentClass?: ClassValue;
   footerClass?: ClassValue;
 };
+
+export type { CardSplit };

--- a/packages/ui/src/components/checkbox/checkbox-control.vue
+++ b/packages/ui/src/components/checkbox/checkbox-control.vue
@@ -1,32 +1,28 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { CheckboxRoot, useForwardPropsEmits } from 'radix-vue';
-import type { CheckboxRootEmits } from 'radix-vue';
 import { checkboxVariants, cn } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
-import type { CheckboxControlProps } from './types';
+import type { CheckboxControlEmits, CheckboxControlProps } from './types';
 
 defineOptions({
   name: 'SCheckboxControl'
 });
 
-const props = defineProps<CheckboxControlProps>();
+const { class: cls, color, size, ...delegatedProps } = defineProps<CheckboxControlProps>();
 
-const delegatedProps = computedOmit(props, ['class']);
-
-const emit = defineEmits<CheckboxRootEmits>();
+const emit = defineEmits<CheckboxControlEmits>();
 
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 
-const cls = computed(() => {
-  const { control } = checkboxVariants({ color: props.color, size: props.size });
+const mergedCls = computed(() => {
+  const { control } = checkboxVariants({ color, size });
 
-  return cn(control(), props.class);
+  return cn(control(), cls);
 });
 </script>
 
 <template>
-  <CheckboxRoot v-bind="forwarded" :class="cls">
+  <CheckboxRoot v-bind="forwarded" :class="mergedCls">
     <slot />
   </CheckboxRoot>
 </template>

--- a/packages/ui/src/components/checkbox/checkbox-group.vue
+++ b/packages/ui/src/components/checkbox/checkbox-group.vue
@@ -2,30 +2,26 @@
 import { computed } from 'vue';
 import { Primitive } from 'radix-vue';
 import { checkboxVariants, cn } from '@soybean-ui/variants';
-import type { CheckboxGroupProps } from './types';
 import SCheckbox from './checkbox.vue';
+import type { CheckboxGroupEmits, CheckboxGroupProps } from './types';
 
 defineOptions({
   name: 'SCheckboxGroup'
 });
 
-const props = defineProps<CheckboxGroupProps>();
+const { class: cls, orientation, values, defaultValues } = defineProps<CheckboxGroupProps>();
 
-type Emits = {
-  'update:values': [values: string[]];
-};
+const emit = defineEmits<CheckboxGroupEmits>();
 
-const emit = defineEmits<Emits>();
+const mergedCls = computed(() => {
+  const { group } = checkboxVariants({ orientation });
 
-const cls = computed(() => {
-  const { group } = checkboxVariants({ orientation: props.orientation });
-
-  return cn(group(), props.class);
+  return cn(group(), cls);
 });
 
 const checks = computed({
   get() {
-    return props.values || props.defaultValues || [];
+    return values || defaultValues || [];
   },
   set(value: string[]) {
     emit('update:values', value);
@@ -42,17 +38,17 @@ function handleUpdateCheckItem(value: string, checked: boolean) {
 </script>
 
 <template>
-  <Primitive as="div" :class="cls">
+  <Primitive as="div" :class="mergedCls">
     <SCheckbox
       v-for="item in items"
       :key="item.value"
       v-bind="item"
       :checked="checks.includes(item.value)"
-      :color="color"
+      :color
+      :size
       :disabled="disabled || item.disabled"
-      @update:checked="handleUpdateCheckItem(item.value, $event as boolean)"
+      @update:checked="handleUpdateCheckItem(item.value, $event)"
     />
-    <!-- BUG: Vue 3.5 @update:checked type error -->
   </Primitive>
 </template>
 

--- a/packages/ui/src/components/checkbox/checkbox-indicator.vue
+++ b/packages/ui/src/components/checkbox/checkbox-indicator.vue
@@ -1,24 +1,22 @@
 <script setup lang="ts">
-import { CheckboxIndicator, useForwardProps } from 'radix-vue';
+import { computed } from 'vue';
+import { CheckboxIndicator } from 'radix-vue';
 import { checkboxVariants, cn } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { CheckboxIndicatorProps } from './types';
 
 defineOptions({
   name: 'SCheckboxIndicator'
 });
 
-const props = defineProps<CheckboxIndicatorProps>();
-
-const delegatedProps = computedOmit(props, ['class']);
-
-const forwarded = useForwardProps(delegatedProps);
+const { class: cls, forceMount } = defineProps<CheckboxIndicatorProps>();
 
 const { indicator } = checkboxVariants();
+
+const mergedCls = computed(() => cn(indicator(), cls));
 </script>
 
 <template>
-  <CheckboxIndicator v-bind="forwarded" :class="cn(indicator(), props.class)">
+  <CheckboxIndicator :class="mergedCls" :force-mount>
     <slot />
   </CheckboxIndicator>
 </template>

--- a/packages/ui/src/components/checkbox/checkbox-root.vue
+++ b/packages/ui/src/components/checkbox/checkbox-root.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { Primitive } from 'radix-vue';
 import { checkboxVariants, cn } from '@soybean-ui/variants';
 import type { CheckboxRootProps } from './types';
@@ -7,13 +8,15 @@ defineOptions({
   name: 'SCheckboxRoot'
 });
 
-const props = defineProps<CheckboxRootProps>();
+const { class: cls } = defineProps<CheckboxRootProps>();
 
 const { root } = checkboxVariants();
+
+const mergedCls = computed(() => cn(root(), cls));
 </script>
 
 <template>
-  <Primitive as="div" :class="cn(root(), props.class)">
+  <Primitive as="div" :class="mergedCls">
     <slot />
   </Primitive>
 </template>

--- a/packages/ui/src/components/checkbox/checkbox.vue
+++ b/packages/ui/src/components/checkbox/checkbox.vue
@@ -1,48 +1,43 @@
 <script setup lang="ts">
 import { computed, useId } from 'vue';
 import { useForwardPropsEmits } from 'radix-vue';
-import type { CheckboxRootEmits } from 'radix-vue';
 import { Check, Minus } from 'lucide-vue-next';
-import { computedOmit } from '../../shared';
 import SCheckboxLabel from '../label/label.vue';
 import SCheckboxRoot from './checkbox-root.vue';
 import SCheckboxControl from './checkbox-control.vue';
 import SCheckboxIndicator from './checkbox-indicator.vue';
-import type { CheckboxCheckedState, CheckboxProps } from './types';
+import type { CheckboxEmits, CheckboxProps } from './types';
 
 defineOptions({
   name: 'SCheckbox'
 });
 
-const props = defineProps<CheckboxProps>();
+const {
+  class: rootCls,
+  id,
+  checked,
+  controlClass,
+  indicatorClass,
+  forceMountIndicator,
+  label,
+  labelClass,
+  ...delegatedProps
+} = defineProps<CheckboxProps>();
 
-const emit = defineEmits<CheckboxRootEmits>();
-
-const delegatedProps = computedOmit(props, [
-  'id',
-  'class',
-  'checked',
-  'controlClass',
-  'indicatorClass',
-  'forceMountIndicator',
-  'label',
-  'labelClass'
-]);
+const emit = defineEmits<CheckboxEmits>();
 
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 
 const defaultId = useId();
 
-const checkboxId = computed(() => props.id || `checkbox-${defaultId}`);
+const checkboxId = computed(() => id || `checkbox-${defaultId}`);
 
-const checked = defineModel<CheckboxCheckedState>('checked', { default: false });
-
-const isIndeterminate = computed(() => checked.value === 'indeterminate');
+const isIndeterminate = computed(() => checked === 'indeterminate');
 </script>
 
 <template>
-  <SCheckboxRoot :class="props.class">
-    <SCheckboxControl v-bind="forwarded" :id="checkboxId" v-model:checked="checked" :class="controlClass">
+  <SCheckboxRoot :class="rootCls">
+    <SCheckboxControl v-bind="forwarded" :id="checkboxId" :class="controlClass">
       <Transition enter-active-class="transition" enter-from-class="opacity-0 scale-0">
         <SCheckboxIndicator :class="indicatorClass" :force-mount="forceMountIndicator">
           <Minus v-if="isIndeterminate" class="size-full" />

--- a/packages/ui/src/components/checkbox/types.ts
+++ b/packages/ui/src/components/checkbox/types.ts
@@ -1,34 +1,28 @@
 import type {
-  CheckboxRootProps as $CheckboxControlProps,
-  CheckboxIndicatorProps as $CheckboxIndicatorProps,
-  CheckboxCheckedState
+  CheckboxCheckedState,
+  CheckboxRootEmits as CheckboxControlEmits,
+  CheckboxRootProps as _CheckboxControlProps,
+  CheckboxIndicatorProps as _CheckboxIndicatorProps
 } from 'radix-vue';
 import type { ThemeColor, ThemeOrientation, ThemeSize } from '@soybean-ui/variants';
-import type { ClassValue } from '../../types';
+import type { ClassValue, ClassValueProp } from '../../types';
 
-export type CheckboxRootProps = {
-  class?: ClassValue;
-};
+export type CheckboxRootProps = ClassValueProp;
 
-export type CheckboxControlProps = $CheckboxControlProps & {
-  class?: ClassValue;
-  color?: ThemeColor;
-  size?: ThemeSize;
-};
+export type CheckboxControlProps = ClassValueProp &
+  Omit<_CheckboxControlProps, 'as' | 'asChild'> & {
+    color?: ThemeColor;
+    size?: ThemeSize;
+  };
 
-export type CheckboxIndicatorProps = $CheckboxIndicatorProps & {
-  class?: ClassValue;
-};
+export type CheckboxIndicatorProps = ClassValueProp & Pick<_CheckboxIndicatorProps, 'forceMount'>;
 
-export type CheckboxProps = $CheckboxControlProps & {
-  class?: ClassValue;
+export type CheckboxProps = CheckboxControlProps & {
   controlClass?: ClassValue;
   indicatorClass?: ClassValue;
   forceMountIndicator?: boolean;
   labelClass?: ClassValue;
   label?: string;
-  color?: ThemeColor;
-  size?: ThemeSize;
 };
 
 export type CheckboxGroupItem = CheckboxProps & {
@@ -36,14 +30,18 @@ export type CheckboxGroupItem = CheckboxProps & {
   value: string;
 };
 
-export type CheckboxGroupProps = {
-  class?: ClassValue;
-  defaultValues?: string[];
-  values?: string[];
-  items?: CheckboxGroupItem[];
-  disabled?: boolean;
-  color?: ThemeColor;
-  orientation?: ThemeOrientation;
+export type CheckboxGroupProps = ClassValueProp &
+  Pick<CheckboxProps, 'color' | 'size' | 'disabled'> & {
+    defaultValues?: string[];
+    values?: string[];
+    items?: CheckboxGroupItem[];
+    orientation?: ThemeOrientation;
+  };
+
+export type CheckboxGroupEmits = {
+  'update:values': [values: string[]];
 };
 
-export type { CheckboxCheckedState };
+export type CheckboxEmits = CheckboxControlEmits;
+
+export type { CheckboxControlEmits, CheckboxCheckedState };

--- a/packages/ui/src/components/collapsible/collapsible-content.vue
+++ b/packages/ui/src/components/collapsible/collapsible-content.vue
@@ -1,22 +1,20 @@
 <script setup lang="ts">
-import { CollapsibleContent, useForwardProps } from 'radix-vue';
+import { computed } from 'vue';
+import { CollapsibleContent } from 'radix-vue';
 import { cn, collapsibleVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { CollapsibleContentProps } from './types';
 
 defineOptions({
   name: 'SCollapsibleContent'
 });
 
-const props = defineProps<CollapsibleContentProps>();
+const { class: cls, forceMount } = defineProps<CollapsibleContentProps>();
 
-const delegatedProps = computedOmit(props, ['class']);
-
-const forwardedProps = useForwardProps(delegatedProps);
+const mergedCls = computed(() => cn(collapsibleVariants(), cls));
 </script>
 
 <template>
-  <CollapsibleContent v-bind="forwardedProps" :class="cn(collapsibleVariants(), props.class)">
+  <CollapsibleContent :class="mergedCls" :force-mount>
     <slot />
   </CollapsibleContent>
 </template>

--- a/packages/ui/src/components/collapsible/collapsible.vue
+++ b/packages/ui/src/components/collapsible/collapsible.vue
@@ -1,28 +1,27 @@
 <script setup lang="ts">
-import { CollapsibleRoot, useForwardPropsEmits } from 'radix-vue';
-import type { CollapsibleRootEmits } from 'radix-vue';
-import { computedOmit } from '../../shared';
+import { CollapsibleRoot, CollapsibleTrigger, useForwardPropsEmits } from 'radix-vue';
 import SCollapsibleContent from './collapsible-content.vue';
-import type { CollapsibleProps } from './types';
+import type { CollapsibleEmits, CollapsibleProps } from './types';
 
 defineOptions({
   name: 'SCollapsible'
 });
 
-const props = defineProps<CollapsibleProps>();
+const { contentClass, forceMountContent, ...delegatedProps } = defineProps<CollapsibleProps>();
 
-const emit = defineEmits<CollapsibleRootEmits>();
-
-const delegatedProps = computedOmit(props, ['contentClass', 'forceMountContent']);
+const emit = defineEmits<CollapsibleEmits>();
 
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 </script>
 
 <template>
-  <CollapsibleRoot v-slot="slotProps" v-bind="forwarded">
-    <slot v-bind="slotProps"></slot>
+  <CollapsibleRoot v-slot="{ open }" v-bind="forwarded">
+    <CollapsibleTrigger v-if="$slots.trigger" as-child>
+      <slot name="trigger" v-bind="{ open }" />
+    </CollapsibleTrigger>
+    <slot v-bind="{ open }"></slot>
     <SCollapsibleContent :class="contentClass" :force-mount="forceMountContent">
-      <slot name="content" v-bind="slotProps" />
+      <slot name="content" v-bind="{ open }" />
     </SCollapsibleContent>
   </CollapsibleRoot>
 </template>

--- a/packages/ui/src/components/collapsible/types.ts
+++ b/packages/ui/src/components/collapsible/types.ts
@@ -1,17 +1,19 @@
 import type {
-  CollapsibleContentProps as $CollapsibleContentProps,
-  CollapsibleRootProps,
-  CollapsibleTriggerProps
+  CollapsibleRootEmits,
+  CollapsibleContentProps as _CollapsibleContentProps,
+  CollapsibleRootProps as _CollapsibleRootProps
 } from 'radix-vue';
-import type { ClassValue } from '../../types';
+import type { ClassValue, ClassValueProp } from '../../types';
 
-export type CollapsibleContentProps = $CollapsibleContentProps & {
-  class?: ClassValue;
-};
+export type CollapsibleRootProps = ClassValueProp & Pick<_CollapsibleRootProps, 'open' | 'defaultOpen' | 'disabled'>;
+
+export type CollapsibleContentProps = Pick<_CollapsibleContentProps, 'forceMount'> & ClassValueProp;
 
 export type CollapsibleProps = CollapsibleRootProps & {
   contentClass?: ClassValue;
   forceMountContent?: boolean;
 };
 
-export type { CollapsibleRootProps, CollapsibleTriggerProps };
+export type CollapsibleEmits = CollapsibleRootEmits;
+
+export type { CollapsibleRootEmits };

--- a/packages/ui/src/components/dialog/dialog-content.vue
+++ b/packages/ui/src/components/dialog/dialog-content.vue
@@ -6,12 +6,11 @@ import {
   DialogDescription,
   DialogTitle,
   VisuallyHidden,
-  useForwardProps,
-  useForwardPropsEmits
+  useEmitAsProps,
+  useForwardProps
 } from 'radix-vue';
 import { X } from 'lucide-vue-next';
 import { cn, dialogVariants } from '@soybean-ui/variants';
-import { computedOmit, computedPick } from '../../shared';
 import SCard from '../card/card.vue';
 import SButtonIcon from '../button/button-icon.vue';
 import type { DialogContentEmits, DialogContentProps } from './types';
@@ -20,7 +19,15 @@ defineOptions({
   name: 'SDialogContent'
 });
 
-const { class: cls, showClose = true, footerClass, ...delegatedProps } = defineProps<DialogContentProps>();
+const {
+  class: cls,
+  showClose = true,
+  footerClass,
+  forceMount,
+  trapFocus,
+  disableOutsidePointerEvents,
+  ...delegatedCardProps
+} = defineProps<DialogContentProps>();
 
 const emit = defineEmits<DialogContentEmits>();
 
@@ -38,11 +45,7 @@ type Slots = {
 
 const slots = defineSlots<Slots>();
 
-const delegatedContentProps = computedPick(delegatedProps, ['forceMount', 'trapFocus', 'disableOutsidePointerEvents']);
-
-const forwardedContent = useForwardPropsEmits(delegatedContentProps, emit);
-
-const delegatedCardProps = computedOmit(delegatedProps, ['forceMount', 'trapFocus', 'disableOutsidePointerEvents']);
+const forwardedContentEmits = useEmitAsProps(emit);
 
 const forwardedCardProps = useForwardProps(delegatedCardProps);
 
@@ -66,7 +69,7 @@ const mergedFooterCls = computed(() => cn(cardFooter(), footerClass));
 </script>
 
 <template>
-  <DialogContent as-child v-bind="forwardedContent">
+  <DialogContent v-bind="forwardedContentEmits" as-child :force-mount :trap-focus :disable-outside-pointer-events>
     <SCard v-bind="forwardedCardProps" :class="mergedCls" :footer-class="mergedFooterCls">
       <VisuallyHidden>
         <DialogTitle />

--- a/packages/ui/src/components/dialog/dialog-overlay.vue
+++ b/packages/ui/src/components/dialog/dialog-overlay.vue
@@ -10,11 +10,9 @@ defineOptions({
 
 const { class: cls, forceMount } = defineProps<DialogOverlayProps>();
 
-const mergedCls = computed(() => {
-  const { overlay } = dialogVariants();
+const { overlay } = dialogVariants();
 
-  return cn(overlay(), cls);
-});
+const mergedCls = computed(() => cn(overlay(), cls));
 </script>
 
 <template>

--- a/packages/ui/src/components/dialog/types.ts
+++ b/packages/ui/src/components/dialog/types.ts
@@ -1,20 +1,18 @@
 import type {
-  DialogContentProps as $DialogContentProps,
-  DialogOverlayProps as $DialogOverlayProps,
   DialogContentEmits,
   DialogPortalProps,
   DialogRootEmits,
-  DialogRootProps
+  DialogRootProps,
+  DialogContentProps as _DialogContentProps,
+  DialogOverlayProps as _DialogOverlayProps
 } from 'radix-vue';
-import type { ClassValue } from '../../types';
+import type { ClassValue, ClassValueProp } from '../../types';
 import type { CardProps } from '../card/types';
 
-export type DialogOverlayProps = Pick<$DialogOverlayProps, 'forceMount'> & {
-  class?: ClassValue;
-};
+export type DialogOverlayProps = ClassValueProp & Pick<_DialogOverlayProps, 'forceMount'>;
 
-export type DialogContentProps = Pick<$DialogContentProps, 'forceMount' | 'trapFocus' | 'disableOutsidePointerEvents'> &
-  CardProps & {
+export type DialogContentProps = CardProps &
+  Pick<_DialogContentProps, 'forceMount' | 'trapFocus' | 'disableOutsidePointerEvents'> & {
     showClose?: boolean;
   };
 

--- a/packages/ui/src/components/drawer/drawer-content.vue
+++ b/packages/ui/src/components/drawer/drawer-content.vue
@@ -19,7 +19,7 @@ const {
   closeClass,
   cardClass,
   footerClass,
-  ...delegatedProps
+  ...delegatedCardProps
 } = defineProps<DrawerContentProps>();
 
 type Slots = {
@@ -36,7 +36,7 @@ type Slots = {
 
 const slots = defineSlots<Slots>();
 
-const forwardedCardProps = useForwardProps(delegatedProps);
+const forwardedCardProps = useForwardProps(delegatedCardProps);
 
 const slotKeys = computed(() => {
   const allKeys = Object.keys(slots) as (keyof Slots)[];

--- a/packages/ui/src/components/drawer/drawer-knob.vue
+++ b/packages/ui/src/components/drawer/drawer-knob.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { Primitive } from 'radix-vue';
 import { cn, drawerVariants } from '@soybean-ui/variants';
 import type { DrawerKnobProps } from './types';
@@ -7,13 +8,15 @@ defineOptions({
   name: 'SDrawerKnob'
 });
 
-const props = defineProps<DrawerKnobProps>();
+const { class: cls } = defineProps<DrawerKnobProps>();
 
 const { knob } = drawerVariants();
+
+const mergedCls = computed(() => cn(knob(), cls));
 </script>
 
 <template>
-  <Primitive as="div" :class="cn(knob(), props.class)" />
+  <Primitive as="div" :class="mergedCls" />
 </template>
 
 <style scoped></style>

--- a/packages/ui/src/components/drawer/drawer-overlay.vue
+++ b/packages/ui/src/components/drawer/drawer-overlay.vue
@@ -10,11 +10,9 @@ defineOptions({
 
 const { class: cls } = defineProps<DrawerOverlayProps>();
 
-const mergedCls = computed(() => {
-  const { overlay } = drawerVariants();
+const { overlay } = drawerVariants();
 
-  return cn(overlay(), cls);
-});
+const mergedCls = computed(() => cn(overlay(), cls));
 </script>
 
 <template>

--- a/packages/ui/src/components/drawer/types.ts
+++ b/packages/ui/src/components/drawer/types.ts
@@ -1,27 +1,21 @@
 import type { DrawerPortalProps, DrawerRootEmits, DrawerRootProps } from 'vaul-vue';
-import type { ClassValue } from '../../types';
+import type { ClassValue, ClassValueProp } from '../../types';
 import type { CardProps } from '../card/types';
 
-export type DrawerOverlayProps = {
-  class?: ClassValue;
-};
+export type DrawerOverlayProps = ClassValueProp;
 
-export type DrawerContentProps = CardProps & {
-  class?: ClassValue;
-  cardClass?: ClassValue;
-  showClose?: boolean;
-  closeClass?: ClassValue;
-};
-export type DrawerTitleProps = {
-  class?: ClassValue;
-};
-export type DrawerDescriptionProps = {
-  class?: ClassValue;
-};
+export type DrawerContentProps = ClassValueProp &
+  CardProps & {
+    cardClass?: ClassValue;
+    showClose?: boolean;
+    closeClass?: ClassValue;
+  };
 
-export type DrawerKnobProps = {
-  class?: ClassValue;
-};
+export type DrawerTitleProps = ClassValueProp;
+
+export type DrawerDescriptionProps = ClassValueProp;
+
+export type DrawerKnobProps = ClassValueProp;
 
 export type DrawerProps = DrawerRootProps &
   DrawerContentProps &

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-arrow.vue
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-arrow.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { DropdownMenuArrow } from 'radix-vue';
 import { cn, dropdownMenuVariants } from '@soybean-ui/variants';
 import type { DropdownMenuArrowProps } from './types';
@@ -7,14 +8,16 @@ defineOptions({
   name: 'SDropdownMenuArrow'
 });
 
-const props = defineProps<DropdownMenuArrowProps>();
+const { class: cls } = defineProps<DropdownMenuArrowProps>();
 
 const { arrow } = dropdownMenuVariants();
+
+const mergedCls = computed(() => cn(arrow(), cls));
 </script>
 
 <template>
   <DropdownMenuArrow as-child>
-    <span :class="cn(arrow(), props.class)"></span>
+    <span :class="mergedCls"></span>
   </DropdownMenuArrow>
 </template>
 

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-checkbox-item.vue
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-checkbox-item.vue
@@ -1,35 +1,31 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { DropdownMenuCheckboxItem, useForwardPropsEmits } from 'radix-vue';
-import type { DropdownMenuCheckboxItemEmits } from 'radix-vue';
 import { Check } from 'lucide-vue-next';
 import { cn, dropdownMenuVariants } from '@soybean-ui/variants';
-import { computed } from 'vue';
-import { computedOmit } from '../../shared';
-import type { DropdownMenuCheckboxItemProps } from './types';
 import SDropdownMenuItemIndicator from './dropdown-menu-indicator.vue';
+import type { DropdownMenuCheckboxItemEmits, DropdownMenuCheckboxItemProps } from './types';
 
 defineOptions({
   name: 'SDropdownMenuCheckboxItem'
 });
 
-const props = defineProps<DropdownMenuCheckboxItemProps>();
+const { class: cls, size, indicatorClass, ...delegatedProps } = defineProps<DropdownMenuCheckboxItemProps>();
 
 const emit = defineEmits<DropdownMenuCheckboxItemEmits>();
 
-const delegatedProps = computedOmit(props, ['class', 'size']);
-
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 
-const cls = computed(() => {
-  const { checkboxItem } = dropdownMenuVariants({ size: props.size });
+const mergedCls = computed(() => {
+  const { checkboxItem } = dropdownMenuVariants({ size });
 
-  return cn(checkboxItem(), props.class);
+  return cn(checkboxItem(), cls);
 });
 </script>
 
 <template>
-  <DropdownMenuCheckboxItem v-bind="forwarded" :class="cls">
-    <SDropdownMenuItemIndicator :size="size">
+  <DropdownMenuCheckboxItem v-bind="forwarded" :class="mergedCls">
+    <SDropdownMenuItemIndicator :class="indicatorClass" :size>
       <slot name="indicatorIcon">
         <Check />
       </slot>

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-checkbox.vue
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-checkbox.vue
@@ -12,8 +12,7 @@ import type {
   CheckAction,
   DropdownMenuCheckboxEmits,
   DropdownMenuCheckboxOption,
-  DropdownMenuCheckboxProps,
-  DropdownMenuWrapperEmits
+  DropdownMenuCheckboxProps
 } from './types';
 
 defineOptions({
@@ -22,11 +21,9 @@ defineOptions({
 
 const props = defineProps<DropdownMenuCheckboxProps<T>>();
 
-type Emits = DropdownMenuWrapperEmits & DropdownMenuCheckboxEmits;
+const emit = defineEmits<DropdownMenuCheckboxEmits>();
 
-const emit = defineEmits<Emits>();
-
-const forwardedEmits = useEmitAsProps(emit) as Record<keyof Emits, any>;
+const forwardedEmits = useEmitAsProps(emit) as Record<keyof DropdownMenuCheckboxEmits, any>;
 
 const delegatedWrapperProps = computedOmit(props, [
   'separator',

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-content.vue
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-content.vue
@@ -1,29 +1,26 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { DropdownMenuContent, useForwardPropsEmits } from 'radix-vue';
-import type { DropdownMenuContentEmits } from 'radix-vue';
 import { cn, dropdownMenuVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
-import type { DropdownMenuContentProps } from './types';
+import type { DropdownMenuContentEmits, DropdownMenuContentProps } from './types';
 
 defineOptions({
   name: 'SDropdownMenuContent'
 });
 
-const props = withDefaults(defineProps<DropdownMenuContentProps>(), {
-  sideOffset: 8
-});
+const { class: cls, sideOffset = 8, ...delegatedProps } = defineProps<DropdownMenuContentProps>();
 
 const emit = defineEmits<DropdownMenuContentEmits>();
-
-const delegatedProps = computedOmit(props, ['class']);
 
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 
 const { content } = dropdownMenuVariants();
+
+const mergedCls = computed(() => cn(content(), cls));
 </script>
 
 <template>
-  <DropdownMenuContent v-bind="forwarded" :class="cn(content(), props.class)">
+  <DropdownMenuContent v-bind="forwarded" :class="mergedCls" :side-offset>
     <slot />
   </DropdownMenuContent>
 </template>

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-indicator.vue
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-indicator.vue
@@ -2,28 +2,25 @@
 import { computed } from 'vue';
 import { DropdownMenuItemIndicator, useForwardProps } from 'radix-vue';
 import { cn, dropdownMenuVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { DropdownMenuItemIndicatorProps } from './types';
 
 defineOptions({
   name: 'SDropdownMenuItemIndicator'
 });
 
-const props = defineProps<DropdownMenuItemIndicatorProps>();
+const { class: cls, size, ...delegatedProps } = defineProps<DropdownMenuItemIndicatorProps>();
 
-const delegatedProps = computedOmit(props, ['class', 'size']);
+const forwardedProps = useForwardProps(delegatedProps);
 
-const forwarded = useForwardProps(delegatedProps);
+const mergedCls = computed(() => {
+  const { itemIndicator } = dropdownMenuVariants({ size });
 
-const cls = computed(() => {
-  const { checkboxItemIndicator } = dropdownMenuVariants({ size: props.size });
-
-  return cn(checkboxItemIndicator(), props.class);
+  return cn(itemIndicator(), cls);
 });
 </script>
 
 <template>
-  <DropdownMenuItemIndicator :class="cls" v-bind="forwarded">
+  <DropdownMenuItemIndicator v-bind="forwardedProps" :class="mergedCls">
     <slot></slot>
   </DropdownMenuItemIndicator>
 </template>

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-item.vue
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-item.vue
@@ -3,30 +3,27 @@ import { computed } from 'vue';
 import { DropdownMenuItem, useForwardPropsEmits } from 'radix-vue';
 import type { DropdownMenuItemEmits } from 'radix-vue';
 import { cn, dropdownMenuVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { DropdownMenuItemProps } from './types';
 
 defineOptions({
   name: 'SDropdownMenuItem'
 });
 
-const props = defineProps<DropdownMenuItemProps>();
+const { class: cls, size, ...delegatedProps } = defineProps<DropdownMenuItemProps>();
 
 const emit = defineEmits<DropdownMenuItemEmits>();
 
-const delegatedProps = computedOmit(props, ['class', 'size']);
-
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 
-const cls = computed(() => {
-  const { item } = dropdownMenuVariants({ size: props.size });
+const mergedCls = computed(() => {
+  const { item } = dropdownMenuVariants({ size });
 
-  return cn(item(), props.class);
+  return cn(item(), cls);
 });
 </script>
 
 <template>
-  <DropdownMenuItem v-bind="forwarded" :class="cls">
+  <DropdownMenuItem v-bind="forwarded" :class="mergedCls">
     <slot />
   </DropdownMenuItem>
 </template>

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-label.vue
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-label.vue
@@ -8,17 +8,17 @@ defineOptions({
   name: 'SDropdownMenuLabel'
 });
 
-const props = defineProps<DropdownMenuLabelProps>();
+const { class: cls, size } = defineProps<DropdownMenuLabelProps>();
 
-const cls = computed(() => {
-  const { label } = dropdownMenuVariants({ size: props.size });
+const mergedCls = computed(() => {
+  const { label } = dropdownMenuVariants({ size });
 
-  return cn(label(), props.class);
+  return cn(label(), cls);
 });
 </script>
 
 <template>
-  <DropdownMenuLabel :class="cls">
+  <DropdownMenuLabel :class="mergedCls">
     <slot />
   </DropdownMenuLabel>
 </template>

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-option.vue
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-option.vue
@@ -15,9 +15,7 @@ defineOptions({
 
 defineProps<DropdownMenuOptionProps<T>>();
 
-type Emits = DropdownMenuOptionEmits<T>;
-
-const emit = defineEmits<Emits>();
+const emit = defineEmits<DropdownMenuOptionEmits<T>>();
 
 const forwardedEmits = useEmitAsProps(emit);
 </script>

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-radio-indicator-icon-root.vue
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-radio-indicator-icon-root.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Primitive } from 'radix-vue';
+import { cn, dropdownMenuVariants } from '@soybean-ui/variants';
+import type { DropdownMenuRadioIndicatorIconRootProps } from './types';
+
+defineOptions({
+  name: 'SDropdownMenuRadioIndicatorIconRoot'
+});
+
+const { class: cls } = defineProps<DropdownMenuRadioIndicatorIconRootProps>();
+
+const { radioIndicatorIconRoot } = dropdownMenuVariants();
+
+const mergedCls = computed(() => {
+  return cn(radioIndicatorIconRoot(), cls);
+});
+</script>
+
+<template>
+  <Primitive as="div" :class="mergedCls">
+    <slot />
+  </Primitive>
+</template>
+
+<style scoped></style>

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-radio-indicator-icon.vue
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-radio-indicator-icon.vue
@@ -1,13 +1,24 @@
 <script setup lang="ts">
+import { computed } from 'vue';
+import { Primitive } from 'radix-vue';
+import { cn, dropdownMenuVariants } from '@soybean-ui/variants';
+import type { DropdownMenuRadioIndicatorIconProps } from './types';
+
 defineOptions({
   name: 'SDropdownMenuRadioIndicatorIcon'
+});
+
+const { class: cls } = defineProps<DropdownMenuRadioIndicatorIconProps>();
+
+const { radioIndicatorIcon } = dropdownMenuVariants();
+
+const mergedCls = computed(() => {
+  return cn(radioIndicatorIcon(), cls);
 });
 </script>
 
 <template>
-  <div class="size-1.25em flex items-center justify-center">
-    <div class="size-1/2 rounded-full bg-primary"></div>
-  </div>
+  <Primitive as="div" :class="mergedCls" />
 </template>
 
 <style scoped></style>

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-radio-item.vue
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-radio-item.vue
@@ -1,37 +1,43 @@
 <script setup lang="ts">
-import { DropdownMenuRadioItem, useForwardPropsEmits } from 'radix-vue';
-import type { DropdownMenuRadioItemEmits } from 'radix-vue';
-import { cn, dropdownMenuVariants } from '@soybean-ui/variants';
 import { computed } from 'vue';
-import { computedOmit } from '../../shared';
-import type { DropdownMenuRadioItemProps } from './types';
+import { DropdownMenuRadioItem, useForwardPropsEmits } from 'radix-vue';
+import { cn, dropdownMenuVariants } from '@soybean-ui/variants';
 import SDropdownMenuItemIndicator from './dropdown-menu-indicator.vue';
+import SDropdownMenuRadioIndicatorIconRoot from './dropdown-menu-radio-indicator-icon-root.vue';
 import SDropdownMenuRadioIndicatorIcon from './dropdown-menu-radio-indicator-icon.vue';
+import type { DropdownMenuRadioItemEmits, DropdownMenuRadioItemProps } from './types';
 
 defineOptions({
   name: 'SDropdownMenuRadioItem'
 });
 
-const props = defineProps<DropdownMenuRadioItemProps>();
+const {
+  class: cls,
+  size,
+  indicatorClass,
+  indicatorIconRootClass,
+  indicatorIconClass,
+  ...delegatedProps
+} = defineProps<DropdownMenuRadioItemProps>();
 
 const emit = defineEmits<DropdownMenuRadioItemEmits>();
 
-const delegatedProps = computedOmit(props, ['class', 'size']);
-
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 
-const cls = computed(() => {
-  const { radioItem } = dropdownMenuVariants({ size: props.size });
+const mergedCls = computed(() => {
+  const { radioItem } = dropdownMenuVariants({ size });
 
-  return cn(radioItem(), props.class);
+  return cn(radioItem(), cls);
 });
 </script>
 
 <template>
-  <DropdownMenuRadioItem v-bind="forwarded" :class="cls">
-    <SDropdownMenuItemIndicator :size="size">
+  <DropdownMenuRadioItem v-bind="forwarded" :class="mergedCls">
+    <SDropdownMenuItemIndicator :class="indicatorClass" :size="size">
       <slot name="indicatorIcon">
-        <SDropdownMenuRadioIndicatorIcon />
+        <SDropdownMenuRadioIndicatorIconRoot :class="indicatorIconRootClass">
+          <SDropdownMenuRadioIndicatorIcon :class="indicatorIconClass" />
+        </SDropdownMenuRadioIndicatorIconRoot>
       </slot>
     </SDropdownMenuItemIndicator>
     <slot></slot>

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-radio.vue
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-radio.vue
@@ -1,14 +1,13 @@
 <script setup lang="ts" generic="T extends DropdownMenuRadioOption = DropdownMenuRadioOption">
 import { computed } from 'vue';
 import { DropdownMenuRadioGroup, useEmitAsProps, useForwardProps } from 'radix-vue';
-import type { DropdownMenuRadioGroupEmits } from 'radix-vue';
 import { computedOmit, computedOmitEmits } from '../../shared';
 import SDropdownMenuWrapper from './dropdown-menu-wrapper.vue';
 import SDropdownMenuLabel from './dropdown-menu-label.vue';
 import SDropdownMenuRadioItem from './dropdown-menu-radio-item.vue';
 import SDropdownMenuShortcut from './dropdown-menu-shortcut.vue';
 import SDropdownMenuSeparator from './dropdown-menu-separator.vue';
-import type { DropdownMenuRadioOption, DropdownMenuRadioProps, DropdownMenuWrapperEmits } from './types';
+import type { DropdownMenuRadioEmits, DropdownMenuRadioOption, DropdownMenuRadioProps } from './types';
 
 defineOptions({
   name: 'SDropdownMenuRadio'
@@ -16,11 +15,9 @@ defineOptions({
 
 const props = defineProps<DropdownMenuRadioProps<T>>();
 
-type Emits = DropdownMenuWrapperEmits & DropdownMenuRadioGroupEmits;
+const emit = defineEmits<DropdownMenuRadioEmits>();
 
-const emit = defineEmits<Emits>();
-
-const forwardedEmits = useEmitAsProps(emit) as Record<keyof Emits, any>;
+const forwardedEmits = useEmitAsProps(emit) as Record<keyof DropdownMenuRadioEmits, any>;
 
 const delegatedWrapperProps = computedOmit(props, [
   'separator',
@@ -33,7 +30,10 @@ const delegatedWrapperProps = computedOmit(props, [
   'modelValue',
   'defaultValue',
   'groupLabel',
-  'groupSeparator'
+  'groupSeparator',
+  'indicatorClass',
+  'indicatorIconRootClass',
+  'indicatorIconClass'
 ]);
 
 const forwardedWrapperProps = useForwardProps(delegatedWrapperProps);
@@ -72,6 +72,9 @@ const radioValue = computed({
           :disabled="item.disabled"
           :text-value="item.textValue || item.label"
           :value="item.value"
+          :indicator-class
+          :indicator-icon-root-class
+          :indicator-icon-class
         >
           <template #indicatorIcon>
             <slot name="indicatorIcon" />

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-separator.vue
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-separator.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { DropdownMenuSeparator } from 'radix-vue';
 import { cn, dropdownMenuVariants } from '@soybean-ui/variants';
 import type { DropdownMenuSeparatorProps } from './types';
@@ -7,13 +8,15 @@ defineOptions({
   name: 'SDropdownMenuSeparator'
 });
 
-const props = defineProps<DropdownMenuSeparatorProps>();
+const { class: cls } = defineProps<DropdownMenuSeparatorProps>();
 
 const { separator } = dropdownMenuVariants();
+
+const mergedCls = computed(() => cn(separator(), cls));
 </script>
 
 <template>
-  <DropdownMenuSeparator :class="cn(separator(), props.class)" />
+  <DropdownMenuSeparator :class="mergedCls" />
 </template>
 
 <style scoped></style>

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-shortcut.vue
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-shortcut.vue
@@ -8,17 +8,17 @@ defineOptions({
   name: 'SDropdownMenuShortcut'
 });
 
-const props = defineProps<DropdownMenuShortcutProps>();
+const { class: cls, size } = defineProps<DropdownMenuShortcutProps>();
 
-const cls = computed(() => {
-  const { shortcut } = dropdownMenuVariants({ size: props.size });
+const mergedCls = computed(() => {
+  const { shortcut } = dropdownMenuVariants({ size });
 
-  return cn(shortcut(), props.class);
+  return cn(shortcut(), cls);
 });
 </script>
 
 <template>
-  <Primitive as="div" :class="cls">
+  <Primitive as="div" :class="mergedCls">
     <slot />
   </Primitive>
 </template>

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-sub-content.vue
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-sub-content.vue
@@ -1,27 +1,27 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { DropdownMenuSubContent, useForwardPropsEmits } from 'radix-vue';
 import type { DropdownMenuSubContentEmits } from 'radix-vue';
 import { cn, dropdownMenuVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { DropdownMenuSubContentProps } from './types';
 
 defineOptions({
   name: 'SDropdownMenuSubContent'
 });
 
-const props = defineProps<DropdownMenuSubContentProps>();
+const { class: cls, ...delegatedProps } = defineProps<DropdownMenuSubContentProps>();
 
 const emit = defineEmits<DropdownMenuSubContentEmits>();
-
-const delegatedProps = computedOmit(props, ['class']);
 
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 
 const { subContent } = dropdownMenuVariants();
+
+const mergedCls = computed(() => cn(subContent(), cls));
 </script>
 
 <template>
-  <DropdownMenuSubContent v-bind="forwarded" :class="cn(subContent(), props.class)">
+  <DropdownMenuSubContent v-bind="forwarded" :class="mergedCls">
     <slot />
   </DropdownMenuSubContent>
 </template>

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-sub-trigger.vue
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-sub-trigger.vue
@@ -3,33 +3,32 @@ import { computed } from 'vue';
 import { DropdownMenuSubTrigger, useForwardProps } from 'radix-vue';
 import { ChevronRight } from 'lucide-vue-next';
 import { cn, dropdownMenuVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { DropdownMenuSubTriggerProps } from './types';
 
 defineOptions({
   name: 'SDropdownMenuSubTrigger'
 });
 
-const props = defineProps<DropdownMenuSubTriggerProps>();
-
-const delegatedProps = computedOmit(props, ['class', 'size', 'triggerIconClass']);
+const { class: cls, size, triggerIconClass, ...delegatedProps } = defineProps<DropdownMenuSubTriggerProps>();
 
 const forwardedProps = useForwardProps(delegatedProps);
 
-const subTriggerCls = computed(() => {
-  const { subTrigger } = dropdownMenuVariants({ size: props.size });
+const mergedCls = computed(() => {
+  const { subTrigger } = dropdownMenuVariants({ size });
 
-  return cn(subTrigger(), props.class);
+  return cn(subTrigger(), cls);
 });
 
 const { subTriggerIcon } = dropdownMenuVariants();
+
+const subTriggerIconCls = computed(() => cn(subTriggerIcon(), triggerIconClass));
 </script>
 
 <template>
-  <DropdownMenuSubTrigger v-bind="forwardedProps" :class="subTriggerCls">
+  <DropdownMenuSubTrigger v-bind="forwardedProps" :class="mergedCls">
     <slot />
     <slot name="icon">
-      <ChevronRight :class="cn(subTriggerIcon(), props.triggerIconClass)" />
+      <ChevronRight :class="subTriggerIconCls" />
     </slot>
   </DropdownMenuSubTrigger>
 </template>

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu-wrapper.vue
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu-wrapper.vue
@@ -10,33 +10,32 @@ defineOptions({
   name: 'SDropdownMenuWrapper'
 });
 
-const props = withDefaults(defineProps<DropdownMenuWrapperProps>(), {
-  avoidCollisions: true,
-  prioritizePosition: true
-});
+const {
+  avoidCollisions = true,
+  prioritizePosition = true,
+  ...delegatedProps
+} = defineProps<DropdownMenuWrapperProps>();
 
 const emit = defineEmits<DropdownMenuWrapperEmits>();
 
 const forwardedEmits = useEmitAsProps(emit) as Record<keyof DropdownMenuWrapperEmits, any>;
 
-const delegatedRootProps = computedPick(props, ['defaultOpen', 'open', 'dir', 'modal']);
+const delegatedRootProps = computedPick(delegatedProps, ['defaultOpen', 'open', 'dir', 'modal']);
 
 const forwardedRootProps = useForwardProps(delegatedRootProps);
 
-const delegatedContentProps = computedPick(props, [
+const delegatedContentProps = computedPick(delegatedProps, [
   'loop',
   'side',
   'sideOffset',
   'align',
   'alignOffset',
-  'avoidCollisions',
   'collisionBoundary',
   'collisionPadding',
   'arrowPadding',
   'sticky',
   'hideWhenDetached',
-  'updatePositionStrategy',
-  'prioritizePosition'
+  'updatePositionStrategy'
 ]);
 
 const forwardedContentProps = useForwardProps(delegatedContentProps);
@@ -54,8 +53,14 @@ const forwardedContent = computed(() => ({
     <DropdownMenuTrigger as-child>
       <slot name="trigger" />
     </DropdownMenuTrigger>
-    <DropdownMenuPortal :to="to" :disabled="disabledPortal" :force-mount="forceMountPortal"></DropdownMenuPortal>
-    <SDropdownMenuContent v-bind="forwardedContent" :class="contentClass" :force-mount="forceMountContent">
+    <DropdownMenuPortal :to :disabled="disabledPortal" :force-mount="forceMountPortal" />
+    <SDropdownMenuContent
+      v-bind="forwardedContent"
+      :class="contentClass"
+      :avoid-collisions
+      :prioritize-position
+      :force-mount="forceMountContent"
+    >
       <slot />
       <SDropdownMenuArrow v-if="showArrow" />
     </SDropdownMenuContent>

--- a/packages/ui/src/components/dropdown-menu/dropdown-menu.vue
+++ b/packages/ui/src/components/dropdown-menu/dropdown-menu.vue
@@ -5,12 +5,7 @@ import { computedOmit, computedOmitEmits, computedPick, computedPickEmits } from
 import SDropdownMenuWrapper from './dropdown-menu-wrapper.vue';
 import SDropdownMenuOption from './dropdown-menu-option.vue';
 import { createOptionKey } from './shared';
-import type {
-  DropdownMenuItemOption,
-  DropdownMenuOptionEmits,
-  DropdownMenuProps,
-  DropdownMenuWrapperEmits
-} from './types';
+import type { DropdownMenuEmits, DropdownMenuItemOption, DropdownMenuProps } from './types';
 
 defineOptions({
   name: 'SDropdownMenu'
@@ -18,7 +13,7 @@ defineOptions({
 
 const props = defineProps<DropdownMenuProps<T>>();
 
-type Emits = DropdownMenuWrapperEmits & DropdownMenuOptionEmits<T>;
+type Emits = DropdownMenuEmits<T>;
 
 const emit = defineEmits<Emits>();
 

--- a/packages/ui/src/components/dropdown-menu/types.ts
+++ b/packages/ui/src/components/dropdown-menu/types.ts
@@ -1,58 +1,56 @@
 import type { Component } from 'vue';
 import type {
-  DropdownMenuCheckboxItemProps as $DropdownMenuCheckboxItemProps,
-  DropdownMenuContentProps as $DropdownMenuContentProps,
-  DropdownMenuItemIndicatorProps as $DropdownMenuItemIndicatorProps,
-  DropdownMenuItemProps as $DropdownMenuItemProps,
-  DropdownMenuRadioItemProps as $DropdownMenuRadioItemProps,
-  DropdownMenuSubContentProps as $DropdownMenuSubContentProps,
-  DropdownMenuSubTriggerProps as $DropdownMenuSubTriggerProps,
+  DropdownMenuCheckboxItemEmits,
   DropdownMenuContentEmits,
   DropdownMenuPortalProps,
+  DropdownMenuRadioGroupEmits,
+  DropdownMenuRadioItemEmits,
   DropdownMenuRootEmits,
   DropdownMenuRootProps,
-  DropdownMenuSubProps
+  DropdownMenuSubProps,
+  DropdownMenuCheckboxItemProps as _DropdownMenuCheckboxItemProps,
+  DropdownMenuContentProps as _DropdownMenuContentProps,
+  DropdownMenuItemIndicatorProps as _DropdownMenuItemIndicatorProps,
+  DropdownMenuItemProps as _DropdownMenuItemProps,
+  DropdownMenuRadioItemProps as _DropdownMenuRadioItemProps,
+  DropdownMenuSubContentProps as _DropdownMenuSubContentProps,
+  DropdownMenuSubTriggerProps as _DropdownMenuSubTriggerProps
 } from 'radix-vue';
+import type { MenuItemProps } from 'radix-vue/dist/Menu';
 import type { ThemeSize } from '@soybean-ui/variants';
-import type { ClassValue, FocusOutsideEvent, PointerDownOutsideEvent } from '../../types';
+import type { ClassValue, ClassValueProp, FocusOutsideEvent, PointerDownOutsideEvent } from '../../types';
 
-export type DropdownMenuLabelProps = {
-  class?: ClassValue;
+export type DropdownMenuLabelProps = ClassValueProp & {
   size?: ThemeSize;
 };
 
-export type DropdownMenuContentProps = $DropdownMenuContentProps & {
-  class?: ClassValue;
-};
+export type DropdownMenuContentProps = ClassValueProp & Omit<_DropdownMenuContentProps, 'as' | 'asChild'>;
 
-export type DropdownMenuSubContentProps = $DropdownMenuSubContentProps & {
-  class?: ClassValue;
-};
+export type DropdownMenuSubContentProps = ClassValueProp & Omit<_DropdownMenuSubContentProps, 'as' | 'asChild'>;
 
-export type DropdownMenuItemProps = $DropdownMenuItemProps & {
-  class?: ClassValue;
+type MenuItemImplProps = Pick<MenuItemProps, 'disabled' | 'textValue'>;
+
+type MenuItemImplWithClassProps = ClassValueProp & MenuItemImplProps;
+
+export type DropdownMenuItemProps = MenuItemImplWithClassProps & {
   size?: ThemeSize;
   iconClass?: ClassValue;
 };
 
-export type DropdownMenuSubTriggerProps = $DropdownMenuSubTriggerProps & {
-  class?: ClassValue;
+export type DropdownMenuSubTriggerProps = MenuItemImplWithClassProps & {
   size?: ThemeSize;
   triggerIconClass?: ClassValue;
 };
 
-export type DropdownMenuShortcutProps = {
-  class?: ClassValue;
+export type DropdownMenuShortcutProps = ClassValueProp & {
   size?: ThemeSize;
 };
 
-export type DropdownMenuSeparatorProps = {
-  class?: ClassValue;
-};
+export type DropdownMenuSeparatorProps = ClassValueProp;
 
 export type DropdownMenuWrapperProps = DropdownMenuRootProps &
   Pick<DropdownMenuPortalProps, 'to'> &
-  Omit<DropdownMenuContentProps, 'as' | 'asChild' | 'forceMount' | 'class'> & {
+  Omit<DropdownMenuContentProps, 'class' | 'forceMount'> & {
     size?: ThemeSize;
     disabledPortal?: boolean;
     forceMountPortal?: boolean;
@@ -72,7 +70,7 @@ export type DropdownMenuCommonProps = {
   shortcutClass?: ClassValue;
 };
 
-type DropdownMenuOptionCommon = Pick<$DropdownMenuItemProps, 'disabled' | 'textValue'> & {
+type DropdownMenuOptionCommon = MenuItemImplProps & {
   /**
    * The label to display in the dropdown.
    *
@@ -120,7 +118,7 @@ export type DropdownMenuProps<T extends DropdownMenuItemOption = DropdownMenuIte
     subTriggerIconClass?: ClassValue;
     subContentClass?: ClassValue;
     /** if not provided, it will extend from `DropdownMenuContentProps` */
-    subContentProps?: $DropdownMenuSubContentProps;
+    subContentProps?: _DropdownMenuSubContentProps;
   };
 
 export type DropdownMenuOptionProps<T extends DropdownMenuItemOption = DropdownMenuItemOption> = {
@@ -165,15 +163,19 @@ export type DropdownMenuItemEmits<T extends DropdownMenuItemOption = DropdownMen
 export type DropdownMenuOptionEmits<T extends DropdownMenuItemOption = DropdownMenuItemOption> =
   DropdownMenuSubEmits<T> & DropdownMenuSubContentEmits<T> & DropdownMenuItemEmits<T>;
 
-export type DropdownMenuCheckboxItemProps = $DropdownMenuCheckboxItemProps & {
-  class?: ClassValue;
-  size?: ThemeSize;
-};
+export type DropdownMenuEmits<T extends DropdownMenuItemOption = DropdownMenuItemOption> = DropdownMenuWrapperEmits &
+  DropdownMenuOptionEmits<T>;
 
-export type DropdownMenuItemIndicatorProps = $DropdownMenuItemIndicatorProps & {
-  class?: ClassValue;
-  size?: ThemeSize;
-};
+export type DropdownMenuCheckboxItemProps = MenuItemImplWithClassProps &
+  Pick<_DropdownMenuCheckboxItemProps, 'checked'> & {
+    size?: ThemeSize;
+    indicatorClass?: ClassValue;
+  };
+
+export type DropdownMenuItemIndicatorProps = ClassValueProp &
+  Pick<_DropdownMenuItemIndicatorProps, 'forceMount'> & {
+    size?: ThemeSize;
+  };
 
 export type DropdownMenuCheckboxOption = DropdownMenuOptionCommon & {
   value: string;
@@ -193,14 +195,23 @@ export type DropdownMenuCheckboxProps<T extends DropdownMenuCheckboxOption = Dro
 
 export type CheckAction = 'check' | 'uncheck';
 
-export type DropdownMenuCheckboxEmits = {
+export type DropdownMenuCheckboxGroupEmits = {
   'update:modelValue': [payload: string[], item: DropdownMenuCheckboxOption, action: CheckAction];
 };
 
-export type DropdownMenuRadioItemProps = $DropdownMenuRadioItemProps & {
-  class?: ClassValue;
-  size?: ThemeSize;
-};
+export type DropdownMenuCheckboxEmits = DropdownMenuWrapperEmits & DropdownMenuCheckboxGroupEmits;
+
+export type DropdownMenuRadioItemProps = MenuItemImplWithClassProps &
+  Pick<_DropdownMenuRadioItemProps, 'value'> & {
+    size?: ThemeSize;
+    indicatorClass?: ClassValue;
+    indicatorIconRootClass?: ClassValue;
+    indicatorIconClass?: ClassValue;
+  };
+
+export type DropdownMenuRadioIndicatorIconRootProps = ClassValueProp;
+
+export type DropdownMenuRadioIndicatorIconProps = ClassValueProp;
 
 export type DropdownMenuRadioOption = DropdownMenuOptionCommon & {
   value: string;
@@ -216,8 +227,18 @@ export type DropdownMenuRadioProps<T extends DropdownMenuRadioOption = DropdownM
       defaultValue?: string | null;
       groupLabel?: string;
       groupSeparator?: boolean;
+      indicatorClass?: ClassValue;
+      indicatorIconRootClass?: ClassValue;
+      indicatorIconClass?: ClassValue;
     };
 
-export type DropdownMenuArrowProps = {
-  class?: ClassValue;
+export type DropdownMenuRadioEmits = DropdownMenuWrapperEmits & DropdownMenuRadioGroupEmits;
+
+export type DropdownMenuArrowProps = ClassValueProp;
+
+export type {
+  DropdownMenuContentEmits,
+  DropdownMenuCheckboxItemEmits,
+  DropdownMenuRadioGroupEmits,
+  DropdownMenuRadioItemEmits
 };

--- a/packages/ui/src/components/input/input.vue
+++ b/packages/ui/src/components/input/input.vue
@@ -1,26 +1,20 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { Primitive, useForwardProps } from 'radix-vue';
 import { cn, inputVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
-import type { InputProps } from './types';
+import type { InputEmits, InputProps } from './types';
 
 defineOptions({
   name: 'SInput'
 });
 
-const props = defineProps<InputProps>();
+const { class: cls, size, modelValue, defaultValue, ...delegatedProps } = defineProps<InputProps>();
 
-type Emits = {
-  'update:modelValue': [value: string];
-};
-
-const emit = defineEmits<Emits>();
-
-const delegatedProps = computedOmit(props, ['class', 'size', 'modelValue', 'defaultValue']);
+const emit = defineEmits<InputEmits>();
 
 const forwardedProps = useForwardProps(delegatedProps);
 
-const modelValue = defineModel<string>();
+const mergedCls = computed(() => cn(inputVariants({ size }), cls));
 
 function handleInput(event: Event) {
   emit('update:modelValue', (event.target as HTMLInputElement).value);
@@ -32,7 +26,7 @@ function handleInput(event: Event) {
     as="input"
     v-bind="forwardedProps"
     :value="modelValue || defaultValue"
-    :class="cn(inputVariants({ size }), props.class)"
+    :class="mergedCls"
     @input="handleInput"
   />
 </template>

--- a/packages/ui/src/components/input/types.ts
+++ b/packages/ui/src/components/input/types.ts
@@ -1,8 +1,7 @@
 import type { ThemeSize } from '@soybean-ui/variants';
-import type { ClassValue } from '../../types';
+import type { ClassValueProp } from '../../types';
 
-export type InputProps = {
-  class?: ClassValue;
+export type InputProps = ClassValueProp & {
   defaultValue?: string;
   modelValue?: string;
   size?: ThemeSize;
@@ -16,7 +15,7 @@ export type InputProps = {
   checked?: boolean | any[] | Set<any>;
   crossorigin?: string;
   disabled?: boolean;
-  enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send';
+  enterKeyHint?: EnterKeyHint;
   form?: string;
   formaction?: string;
   formenctype?: string;
@@ -38,12 +37,16 @@ export type InputProps = {
   required?: boolean;
   src?: string;
   step?: number;
-  type?: InputTypeHTMLAttribute;
+  type?: InputType;
   value?: any;
   width?: number;
 };
 
-export type InputTypeHTMLAttribute =
+export type InputEmits = {
+  'update:modelValue': [value: string];
+};
+
+export type InputType =
   | 'button'
   | 'checkbox'
   | 'color'
@@ -67,3 +70,5 @@ export type InputTypeHTMLAttribute =
   | 'url'
   | 'week'
   | (string & {});
+
+export type EnterKeyHint = 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send';

--- a/packages/ui/src/components/label/label.vue
+++ b/packages/ui/src/components/label/label.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { Label } from 'radix-vue';
 import { cn, labelVariants } from '@soybean-ui/variants';
 import type { LabelProps } from './types';
@@ -7,11 +8,13 @@ defineOptions({
   name: 'SLabel'
 });
 
-const props = defineProps<LabelProps>();
+const { class: cls, size, for: forId } = defineProps<LabelProps>();
+
+const mergedCls = computed(() => cn(labelVariants({ size }), cls));
 </script>
 
 <template>
-  <Label :for="props.for" :class="cn(labelVariants({ size }), props.class)">
+  <Label :for="forId" :class="mergedCls">
     <slot />
   </Label>
 </template>

--- a/packages/ui/src/components/label/types.ts
+++ b/packages/ui/src/components/label/types.ts
@@ -1,8 +1,8 @@
-import type { LabelProps as $LabelProps } from 'radix-vue';
+import type { LabelProps as _LabelProps } from 'radix-vue';
 import type { ThemeSize } from '@soybean-ui/variants';
-import type { ClassValue } from '../../types';
+import type { ClassValueProp } from '../../types';
 
-export type LabelProps = $LabelProps & {
-  class?: ClassValue;
-  size?: ThemeSize;
-};
+export type LabelProps = ClassValueProp &
+  Pick<_LabelProps, 'for'> & {
+    size?: ThemeSize;
+  };

--- a/packages/ui/src/components/pin-input/index.ts
+++ b/packages/ui/src/components/pin-input/index.ts
@@ -1,5 +1,5 @@
 import SPinInputRoot from './pin-input-root.vue';
-import SPinInputItem from './pin-input-item.vue';
+import SPinInputItem from './pin-input-input.vue';
 import SPinInputSeparator from './pin-input-separator.vue';
 import SPinInput from './pin-input.vue';
 

--- a/packages/ui/src/components/pin-input/pin-input-input.vue
+++ b/packages/ui/src/components/pin-input/pin-input-input.vue
@@ -5,20 +5,20 @@ import { cn, pinInputVariants } from '@soybean-ui/variants';
 import type { PinInputItemProps } from './types';
 
 defineOptions({
-  name: 'SPinInputItem'
+  name: 'SPinInputInput'
 });
 
-const { class: itemCls, size, separate, ...delegatedProps } = defineProps<PinInputItemProps>();
+const { class: cls, size, separate, ...delegatedProps } = defineProps<PinInputItemProps>();
 
 const forwardedProps = useForwardProps(delegatedProps);
 
-const cls = computed(() => {
+const mergedCls = computed(() => {
   const { input } = pinInputVariants({ separate, size });
 
-  return cn(input(), itemCls);
+  return cn(input(), cls);
 });
 </script>
 
 <template>
-  <PinInputInput v-bind="forwardedProps" :class="cls" />
+  <PinInputInput v-bind="forwardedProps" :class="mergedCls" />
 </template>

--- a/packages/ui/src/components/pin-input/pin-input-root.vue
+++ b/packages/ui/src/components/pin-input/pin-input-root.vue
@@ -1,29 +1,28 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { PinInputRoot, useForwardPropsEmits } from 'radix-vue';
-import type { PinInputRootEmits } from 'radix-vue';
 import { cn, pinInputVariants } from '@soybean-ui/variants';
-import type { PinInputRootProps } from './types';
+import type { PinInputRootEmits, PinInputRootProps } from './types';
 
 defineOptions({
   name: 'SPinInputRoot'
 });
 
-const { class: rootCls, separate, ...delegatedProps } = defineProps<PinInputRootProps>();
+const { class: cls, separate, ...delegatedProps } = defineProps<PinInputRootProps>();
 
 const emit = defineEmits<PinInputRootEmits>();
 
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 
-const cls = computed(() => {
+const mergedCls = computed(() => {
   const { root } = pinInputVariants({ separate });
 
-  return cn(root(), rootCls);
+  return cn(root(), cls);
 });
 </script>
 
 <template>
-  <PinInputRoot v-bind="forwarded" :class="cls">
+  <PinInputRoot v-bind="forwarded" :class="mergedCls">
     <slot />
   </PinInputRoot>
 </template>

--- a/packages/ui/src/components/pin-input/pin-input-separator.vue
+++ b/packages/ui/src/components/pin-input/pin-input-separator.vue
@@ -8,19 +8,19 @@ defineOptions({
   name: 'SPinInputSeparator'
 });
 
-const { class: separatorClass, size } = defineProps<PinInputSeparatorProps>();
+const { class: cls, size } = defineProps<PinInputSeparatorProps>();
 
-const cls = computed(() => {
+const mergedCls = computed(() => {
   const { separator } = pinInputVariants({ size });
 
-  return cn(separator(), separatorClass);
+  return cn(separator(), cls);
 });
 
 const BLANK = ' ';
 </script>
 
 <template>
-  <Primitive as="span" :class="cls">
+  <Primitive as="span" :class="mergedCls">
     <slot>{{ BLANK }}</slot>
   </Primitive>
 </template>

--- a/packages/ui/src/components/pin-input/pin-input.vue
+++ b/packages/ui/src/components/pin-input/pin-input.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
 import { computed, useSlots } from 'vue';
 import { useForwardPropsEmits } from 'radix-vue';
-import type { PinInputRootEmits } from 'radix-vue';
 import PinInputRoot from './pin-input-root.vue';
-import PinInputItem from './pin-input-item.vue';
+import PinInputItem from './pin-input-input.vue';
 import PinInputSeparator from './pin-input-separator.vue';
-import type { PinInputProps } from './types';
+import type { PinInputEmits, PinInputProps } from './types';
 
 defineOptions({
   name: 'SPinInput'
@@ -20,15 +19,13 @@ const {
   ...delegatedRootProps
 } = defineProps<PinInputProps>();
 
-const emit = defineEmits<PinInputRootEmits>();
+const emit = defineEmits<PinInputEmits>();
 
 const slots = useSlots();
 
 const forwarded = useForwardPropsEmits(delegatedRootProps, emit);
 
-const hasSeparator = computed(() => {
-  return separate || Boolean(slots.separator);
-});
+const hasSeparator = computed(() => separate || Boolean(slots.separator));
 </script>
 
 <template>

--- a/packages/ui/src/components/pin-input/types.ts
+++ b/packages/ui/src/components/pin-input/types.ts
@@ -1,27 +1,34 @@
-import type { PinInputInputProps as $PinInputItemProps, PinInputRootProps as $PinInputRootProps } from 'radix-vue';
+import type {
+  PinInputRootEmits,
+  PinInputInputProps as _PinInputItemProps,
+  PinInputRootProps as _PinInputRootProps
+} from 'radix-vue';
 import type { ThemeSize } from '@soybean-ui/variants';
-import type { ClassValue } from '../../types';
+import type { ClassValue, ClassValueProp } from '../../types';
 
-export type PinInputRootProps = Omit<$PinInputRootProps, 'as' | 'asChild'> & {
-  class?: ClassValue;
-  separate?: boolean;
-};
+export type PinInputRootProps = ClassValueProp &
+  Omit<_PinInputRootProps, 'as' | 'asChild'> & {
+    separate?: boolean;
+  };
 
-export type PinInputSeparatorProps = {
-  class?: ClassValue;
+export type PinInputSeparatorProps = ClassValueProp & {
   size?: ThemeSize;
 };
 
-export type PinInputItemProps = Omit<$PinInputItemProps, 'as' | 'asChild'> & {
-  class?: ClassValue;
-  size?: ThemeSize;
-  separate?: boolean;
-};
+export type PinInputItemProps = ClassValueProp &
+  Pick<_PinInputItemProps, 'disabled' | 'index'> & {
+    size?: ThemeSize;
+    separate?: boolean;
+  };
 
-export interface PinInputProps extends PinInputRootProps {
+export type PinInputProps = PinInputRootProps & {
   size?: ThemeSize;
   inputCount?: number;
   separate?: boolean;
   itemClass?: ClassValue;
   separatorClass?: ClassValue;
-}
+};
+
+export type PinInputEmits = PinInputRootEmits;
+
+export type { PinInputRootEmits };

--- a/packages/ui/src/components/popover/popover-arrow.vue
+++ b/packages/ui/src/components/popover/popover-arrow.vue
@@ -1,25 +1,23 @@
 <script setup lang="ts">
-import { PopoverArrow, useForwardProps } from 'radix-vue';
+import { computed } from 'vue';
+import { PopoverArrow } from 'radix-vue';
 import { cn, popoverVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { PopoverArrowProps } from './types';
 
 defineOptions({
   name: 'SPopoverArrow'
 });
 
-const props = defineProps<PopoverArrowProps>();
-
-const delegatedProps = computedOmit(props, ['class', 'asChild']);
-
-const forwardedProps = useForwardProps(delegatedProps);
+const { class: cls, width, height } = defineProps<PopoverArrowProps>();
 
 const { arrow } = popoverVariants();
+
+const mergedCls = computed(() => cn(arrow(), cls));
 </script>
 
 <template>
-  <PopoverArrow as-child v-bind="forwardedProps">
-    <div :class="cn(arrow(), props.class)"></div>
+  <PopoverArrow as-child :width :height>
+    <div :class="mergedCls"></div>
   </PopoverArrow>
 </template>
 

--- a/packages/ui/src/components/popover/popover-content.vue
+++ b/packages/ui/src/components/popover/popover-content.vue
@@ -1,34 +1,26 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { PopoverContent, useForwardPropsEmits } from 'radix-vue';
-import type { PopoverContentEmits } from 'radix-vue';
 import { cn, popoverVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
-import type { PopoverContentProps } from './types';
+import type { PopoverContentEmits, PopoverContentProps } from './types';
 
 defineOptions({
   name: 'SPopoverContent'
 });
 
-const props = withDefaults(defineProps<PopoverContentProps>(), {
-  side: 'bottom',
-  sideOffset: 8,
-  align: 'center',
-  avoidCollisions: true,
-  collisionPadding: 0,
-  sticky: 'partial'
-});
+const { class: cls, sideOffset = 8, avoidCollisions = true, ...delegatedProps } = defineProps<PopoverContentProps>();
 
 const emit = defineEmits<PopoverContentEmits>();
-
-const delegatedProps = computedOmit(props, ['class']);
 
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 
 const { content } = popoverVariants();
+
+const mergedCls = computed(() => cn(content(), cls));
 </script>
 
 <template>
-  <PopoverContent v-bind="forwarded" :class="cn(content(), props.class)">
+  <PopoverContent v-bind="forwarded" :class="mergedCls" :side-offset :avoid-collisions>
     <slot />
   </PopoverContent>
 </template>

--- a/packages/ui/src/components/popover/types.ts
+++ b/packages/ui/src/components/popover/types.ts
@@ -1,23 +1,21 @@
 import type {
-  PopoverArrowProps as $PopoverArrowProps,
-  PopoverContentProps as $PopoverContentProps,
   PopoverAnchorProps,
+  PopoverContentEmits,
   PopoverPortalProps,
-  PopoverRootProps
+  PopoverRootEmits,
+  PopoverRootProps,
+  PopoverArrowProps as _PopoverArrowProps,
+  PopoverContentProps as _PopoverContentProps
 } from 'radix-vue';
-import type { ClassValue } from '../../types';
+import type { ClassValue, ClassValueProp } from '../../types';
 
-export type PopoverContentProps = $PopoverContentProps & {
-  class?: ClassValue;
-};
+export type PopoverContentProps = ClassValueProp & Omit<_PopoverContentProps, 'as' | 'asChild'>;
 
-export type PopoverArrowProps = $PopoverArrowProps & {
-  class?: ClassValue;
-};
+export type PopoverArrowProps = ClassValueProp & Pick<_PopoverArrowProps, 'width' | 'height'>;
 
 export type PopoverProps = PopoverRootProps &
   Pick<PopoverPortalProps, 'to'> &
-  Omit<PopoverContentProps, 'as' | 'asChild' | 'forceMount' | 'class'> & {
+  Omit<PopoverContentProps, 'forceMount' | 'class'> & {
     disabledPortal?: boolean;
     forceMountPortal?: boolean;
     contentClass?: ClassValue;
@@ -28,8 +26,10 @@ export type PopoverProps = PopoverRootProps &
     arrowHeight?: number;
   };
 
+export type PopoverEmits = PopoverRootEmits & PopoverContentEmits;
+
 export type PopoverSide = NonNullable<PopoverContentProps['side']>;
 
 export type PopoverAlign = NonNullable<PopoverContentProps['align']>;
 
-export type { PopoverAnchorProps, PopoverPortalProps, PopoverRootProps };
+export type { PopoverAnchorProps, PopoverPortalProps, PopoverRootProps, PopoverRootEmits, PopoverContentEmits };

--- a/packages/ui/src/components/progress/progress-indicator.vue
+++ b/packages/ui/src/components/progress/progress-indicator.vue
@@ -8,19 +8,19 @@ defineOptions({
   name: 'SProgressIndicator'
 });
 
-const props = defineProps<ProgressIndicatorProps>();
+const { class: cls, color, modelValue } = defineProps<ProgressIndicatorProps>();
 
-const cls = computed(() => {
+const mergedCls = computed(() => {
   const { indicator } = progressVariants();
 
-  return cn(indicator({ color: props.color }), props.class);
+  return cn(indicator({ color }), cls);
 });
 
-const style = computed(() => `transform: translateX(-${100 - (props.modelValue || 0)}%);`);
+const style = computed(() => `transform: translateX(-${100 - (modelValue || 0)}%);`);
 </script>
 
 <template>
-  <ProgressIndicator :class="cls" :style="style" />
+  <ProgressIndicator :class="mergedCls" :style="style" />
 </template>
 
 <style scoped></style>

--- a/packages/ui/src/components/progress/progress-root.vue
+++ b/packages/ui/src/components/progress/progress-root.vue
@@ -1,34 +1,28 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { ProgressRoot, useForwardPropsEmits } from 'radix-vue';
-import type { ProgressRootEmits } from 'radix-vue';
 import { cn, progressVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
-import type { ProgressRootProps } from './types';
+import type { ProgressRootEmits, ProgressRootProps } from './types';
 
 defineOptions({
   name: 'SProgressRoot'
 });
 
-const props = withDefaults(defineProps<ProgressRootProps>(), {
-  as: 'div'
-});
+const { class: cls, color, size, ...delegatedProps } = defineProps<ProgressRootProps>();
 
 const emit = defineEmits<ProgressRootEmits>();
 
-const delegatedProps = computedOmit(props, ['class', 'color', 'size']);
-
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 
-const cls = computed(() => {
-  const { root } = progressVariants({ color: props.color, size: props.size });
+const mergedCls = computed(() => {
+  const { root } = progressVariants({ color, size });
 
-  return cn(root(), props.class);
+  return cn(root(), cls);
 });
 </script>
 
 <template>
-  <ProgressRoot v-bind="forwarded" :class="cls">
+  <ProgressRoot v-bind="forwarded" :class="mergedCls">
     <slot />
   </ProgressRoot>
 </template>

--- a/packages/ui/src/components/progress/progress.vue
+++ b/packages/ui/src/components/progress/progress.vue
@@ -1,27 +1,23 @@
 <script setup lang="ts">
 import { useForwardPropsEmits } from 'radix-vue';
-import type { ProgressRootEmits } from 'radix-vue';
-import { computedOmit } from '../../shared';
 import SProgressRoot from './progress-root.vue';
 import SProgressIndicator from './progress-indicator.vue';
-import type { ProgressProps } from './types';
+import type { ProgressEmits, ProgressProps } from './types';
 
 defineOptions({
   name: 'SProgress'
 });
 
-const props = defineProps<ProgressProps>();
+const { indicatorClass, ...delegatedProps } = defineProps<ProgressProps>();
 
-const emit = defineEmits<ProgressRootEmits>();
-
-const delegatedProps = computedOmit(props, ['indicatorClass']);
+const emit = defineEmits<ProgressEmits>();
 
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 </script>
 
 <template>
   <SProgressRoot v-bind="forwarded">
-    <SProgressIndicator :model-value="modelValue" :class="indicatorClass" :color="color" />
+    <SProgressIndicator :class="indicatorClass" :model-value="modelValue" :color="color" />
   </SProgressRoot>
 </template>
 

--- a/packages/ui/src/components/progress/types.ts
+++ b/packages/ui/src/components/progress/types.ts
@@ -1,15 +1,14 @@
-import type { ProgressRootProps as $ProgressRootProps } from 'radix-vue';
+import type { ProgressRootEmits, ProgressRootProps as _ProgressRootProps } from 'radix-vue';
 import type { ThemeColor, ThemeSize } from '@soybean-ui/variants';
-import type { ClassValue } from '../../types';
+import type { ClassValue, ClassValueProp } from '../../types';
 
-export type ProgressRootProps = $ProgressRootProps & {
-  class?: ClassValue;
-  color?: ThemeColor;
-  size?: ThemeSize;
-};
+export type ProgressRootProps = ClassValueProp &
+  Omit<_ProgressRootProps, 'as' | 'asChild'> & {
+    color?: ThemeColor;
+    size?: ThemeSize;
+  };
 
-export type ProgressIndicatorProps = {
-  class?: ClassValue;
+export type ProgressIndicatorProps = ClassValueProp & {
   modelValue?: number | null;
   color?: ThemeColor;
 };
@@ -17,3 +16,7 @@ export type ProgressIndicatorProps = {
 export type ProgressProps = ProgressRootProps & {
   indicatorClass?: ClassValue;
 };
+
+export type ProgressEmits = ProgressRootEmits;
+
+export type { ProgressRootEmits };

--- a/packages/ui/src/components/radio/radio-control.vue
+++ b/packages/ui/src/components/radio/radio-control.vue
@@ -2,28 +2,25 @@
 import { computed } from 'vue';
 import { RadioGroupItem, useForwardProps } from 'radix-vue';
 import { cn, radioVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { RadioControlProps } from './types';
 
 defineOptions({
   name: 'SRadioControl'
 });
 
-const props = defineProps<RadioControlProps>();
+const { class: cls, color, size, ...delegatedProps } = defineProps<RadioControlProps>();
 
-const delegatedProps = computedOmit(props, ['class']);
+const forwardedProps = useForwardProps(delegatedProps);
 
-const forwarded = useForwardProps(delegatedProps);
+const mergedCls = computed(() => {
+  const { control } = radioVariants({ color, size });
 
-const cls = computed(() => {
-  const { control } = radioVariants({ color: props.color, size: props.size });
-
-  return cn(control(), props.class);
+  return cn(control(), cls);
 });
 </script>
 
 <template>
-  <RadioGroupItem v-bind="forwarded" :class="cls">
+  <RadioGroupItem v-bind="forwardedProps" :class="mergedCls">
     <slot />
   </RadioGroupItem>
 </template>

--- a/packages/ui/src/components/radio/radio-group.vue
+++ b/packages/ui/src/components/radio/radio-group.vue
@@ -3,7 +3,6 @@ import { computed } from 'vue';
 import { RadioGroupRoot, useForwardPropsEmits } from 'radix-vue';
 import type { RadioGroupRootEmits } from 'radix-vue';
 import { cn, radioVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { RadioGroupProps } from './types';
 import SRadio from './radio.vue';
 
@@ -11,23 +10,21 @@ defineOptions({
   name: 'SCheckboxGroup'
 });
 
-const props = defineProps<RadioGroupProps>();
-
-const delegatedProps = computedOmit(props, ['class', 'color', 'size', 'items']);
+const { class: cls, color, size, items, orientation, ...delegatedProps } = defineProps<RadioGroupProps>();
 
 const emit = defineEmits<RadioGroupRootEmits>();
 
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 
-const cls = computed(() => {
-  const { group } = radioVariants({ orientation: props.orientation });
+const mergedCls = computed(() => {
+  const { group } = radioVariants({ orientation });
 
-  return cn(group(), props.class);
+  return cn(group(), cls);
 });
 </script>
 
 <template>
-  <RadioGroupRoot v-bind="forwarded" :class="cls">
+  <RadioGroupRoot v-bind="forwarded" :class="mergedCls" :orientation>
     <slot>
       <SRadio v-for="item in items" :key="item.value" v-bind="item" :color="color" :size="size" />
     </slot>

--- a/packages/ui/src/components/radio/radio-indicator.vue
+++ b/packages/ui/src/components/radio/radio-indicator.vue
@@ -2,28 +2,23 @@
 import { computed } from 'vue';
 import { RadioGroupIndicator, useForwardProps } from 'radix-vue';
 import { cn, radioVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { RadioIndicatorProps } from './types';
 
 defineOptions({
   name: 'SRadioIndicator'
 });
 
-const props = defineProps<RadioIndicatorProps>();
+const { class: cls, color, ...delegatedProps } = defineProps<RadioIndicatorProps>();
 
-const delegatedProps = computedOmit(props, ['class']);
+const forwardedProps = useForwardProps(delegatedProps);
 
-const forwarded = useForwardProps(delegatedProps);
+const { indicator } = radioVariants();
 
-const cls = computed(() => {
-  const { indicator } = radioVariants();
-
-  return cn(indicator({ color: props.color }), props.class);
-});
+const mergedCls = computed(() => cn(indicator({ color }), cls));
 </script>
 
 <template>
-  <RadioGroupIndicator v-bind="forwarded" :class="cls" />
+  <RadioGroupIndicator v-bind="forwardedProps" :class="mergedCls" />
 </template>
 
 <style scoped></style>

--- a/packages/ui/src/components/radio/radio-root.vue
+++ b/packages/ui/src/components/radio/radio-root.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { Primitive } from 'radix-vue';
 import { cn, radioVariants } from '@soybean-ui/variants';
 import type { RadioRootProps } from './types';
@@ -7,13 +8,15 @@ defineOptions({
   name: 'SRadioRoot'
 });
 
-const props = defineProps<RadioRootProps>();
+const { class: cls } = defineProps<RadioRootProps>();
 
 const { root } = radioVariants();
+
+const mergedCls = computed(() => cn(root(), cls));
 </script>
 
 <template>
-  <Primitive as="div" :class="cn(root(), props.class)">
+  <Primitive as="div" :class="mergedCls">
     <slot />
   </Primitive>
 </template>

--- a/packages/ui/src/components/radio/radio.vue
+++ b/packages/ui/src/components/radio/radio.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed, useId } from 'vue';
 import { useForwardProps } from 'radix-vue';
-import { computedOmit } from '../../shared';
 import SRadioLabel from '../label/label.vue';
 import SRadioRoot from './radio-root.vue';
 import SRadioControl from './radio-control.vue';
@@ -12,33 +11,32 @@ defineOptions({
   name: 'SRadio'
 });
 
-const props = defineProps<RadioProps>();
+const {
+  class: rootCls,
+  id,
+  controlClass,
+  indicatorClass,
+  forceMountIndicator,
+  label,
+  labelClass,
+  ...delegatedProps
+} = defineProps<RadioProps>();
 
-const delegatedProps = computedOmit(props, [
-  'id',
-  'class',
-  'controlClass',
-  'indicatorClass',
-  'forceMountIndicator',
-  'label',
-  'labelClass'
-]);
-
-const forwarded = useForwardProps(delegatedProps);
+const forwardedProps = useForwardProps(delegatedProps);
 
 const defaultId = useId();
 
-const radioId = computed(() => props.id || `radio-${defaultId}`);
+const radioId = computed(() => id || `radio-${defaultId}`);
 </script>
 
 <template>
-  <SRadioRoot :class="props.class">
-    <SRadioControl v-bind="forwarded" :id="radioId" :class="controlClass">
+  <SRadioRoot :class="rootCls">
+    <SRadioControl v-bind="forwardedProps" :id="radioId" :class="controlClass">
       <Transition enter-active-class="transition" enter-from-class="opacity-0 scale-0">
-        <SRadioIndicator :class="indicatorClass" :color="color" :force-mount="forceMountIndicator" />
+        <SRadioIndicator :class="indicatorClass" :color :force-mount="forceMountIndicator" />
       </Transition>
     </SRadioControl>
-    <SRadioLabel :class="labelClass" :for="radioId" :size="size">
+    <SRadioLabel :class="labelClass" :for="radioId" :size>
       <slot :id="radioId">{{ label }}</slot>
     </SRadioLabel>
   </SRadioRoot>

--- a/packages/ui/src/components/radio/types.ts
+++ b/packages/ui/src/components/radio/types.ts
@@ -1,39 +1,33 @@
 import type {
-  RadioGroupItemProps as $RadioControlProps,
   RadioGroupIndicatorProps,
-  RadioGroupRootProps
+  RadioGroupRootProps,
+  RadioGroupItemProps as _RadioControlProps
 } from 'radix-vue';
 import type { ThemeColor, ThemeSize } from '@soybean-ui/variants';
-import type { ClassValue } from '../../types';
+import type { ClassValue, ClassValueProp } from '../../types';
 
-export type RadioIndicatorProps = RadioGroupIndicatorProps & {
-  class?: ClassValue;
-  color?: ThemeColor;
-};
+export type RadioIndicatorProps = ClassValueProp &
+  Pick<RadioGroupIndicatorProps, 'forceMount'> & {
+    color?: ThemeColor;
+  };
 
-export type RadioControlProps = $RadioControlProps & {
-  class?: ClassValue;
-  color?: ThemeColor;
-  size?: ThemeSize;
-};
+export type RadioControlProps = ClassValueProp &
+  Omit<_RadioControlProps, 'as' | 'asChild'> & {
+    color?: ThemeColor;
+    size?: ThemeSize;
+  };
 
-export type RadioRootProps = {
-  class?: ClassValue;
-};
+export type RadioRootProps = ClassValueProp;
 
-export type RadioLabelProps = {
-  class?: ClassValue;
-};
+export type RadioLabelProps = ClassValueProp;
 
-export type RadioProps = $RadioControlProps & {
-  class?: ClassValue;
+export type RadioProps = RadioControlProps & {
   controlClass?: ClassValue;
   indicatorClass?: ClassValue;
   forceMountIndicator?: boolean;
   labelClass?: ClassValue;
   label?: string;
   color?: ThemeColor;
-  size?: ThemeSize;
 };
 
 export type RadioGroupItemProps = RadioProps & {
@@ -41,7 +35,7 @@ export type RadioGroupItemProps = RadioProps & {
   value: string;
 };
 
-export type RadioGroupProps = RadioGroupRootProps & {
+export type RadioGroupProps = Omit<RadioGroupRootProps, 'as' | 'asChild'> & {
   class?: ClassValue;
   items?: RadioGroupItemProps[];
   color?: ThemeColor;

--- a/packages/ui/src/components/scroll-area/scroll-area-root.vue
+++ b/packages/ui/src/components/scroll-area/scroll-area-root.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { ScrollAreaRoot, useForwardProps } from 'radix-vue';
 import { cn, scrollAreaVariants } from '@soybean-ui/variants';
 import type { ScrollAreaRootProps } from './types';
@@ -12,10 +13,12 @@ const { class: cls, ...delegatedProps } = defineProps<ScrollAreaRootProps>();
 const forwardedProps = useForwardProps(delegatedProps);
 
 const { root } = scrollAreaVariants();
+
+const mergedCls = computed(() => cn(root(), cls));
 </script>
 
 <template>
-  <ScrollAreaRoot v-bind="forwardedProps" :class="cn(root(), cls)">
+  <ScrollAreaRoot v-bind="forwardedProps" :class="mergedCls">
     <slot />
   </ScrollAreaRoot>
 </template>

--- a/packages/ui/src/components/scroll-area/scroll-area-scrollbar.vue
+++ b/packages/ui/src/components/scroll-area/scroll-area-scrollbar.vue
@@ -8,19 +8,19 @@ defineOptions({
   name: 'SScrollAreaThumb'
 });
 
-const { class: scrollbarCls, ...delegatedProps } = defineProps<ScrollAreaScrollbarProps>();
-
-const cls = computed(() => {
-  const { scrollbar } = scrollAreaVariants({ orientation: delegatedProps.orientation });
-
-  return cn(scrollbar(), scrollbarCls);
-});
+const { class: cls, ...delegatedProps } = defineProps<ScrollAreaScrollbarProps>();
 
 const forwardedProps = useForwardProps(delegatedProps);
+
+const mergedCls = computed(() => {
+  const { scrollbar } = scrollAreaVariants({ orientation: delegatedProps.orientation });
+
+  return cn(scrollbar(), cls);
+});
 </script>
 
 <template>
-  <ScrollAreaScrollbar :class="cls" v-bind="forwardedProps">
+  <ScrollAreaScrollbar v-bind="forwardedProps" :class="mergedCls">
     <slot />
   </ScrollAreaScrollbar>
 </template>

--- a/packages/ui/src/components/scroll-area/scroll-area-thumb.vue
+++ b/packages/ui/src/components/scroll-area/scroll-area-thumb.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { ScrollAreaThumb } from 'radix-vue';
 import { cn, scrollAreaVariants } from '@soybean-ui/variants';
 import type { ScrollAreaThumbProps } from './types';
@@ -10,10 +11,12 @@ defineOptions({
 const { class: cls } = defineProps<ScrollAreaThumbProps>();
 
 const { thumb } = scrollAreaVariants();
+
+const mergedCls = computed(() => cn(thumb(), cls));
 </script>
 
 <template>
-  <ScrollAreaThumb :class="cn(thumb(), cls)">
+  <ScrollAreaThumb :class="mergedCls">
     <slot />
   </ScrollAreaThumb>
 </template>

--- a/packages/ui/src/components/scroll-area/scroll-area-viewport.vue
+++ b/packages/ui/src/components/scroll-area/scroll-area-viewport.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { ScrollAreaViewport, useForwardProps } from 'radix-vue';
 import { cn, scrollAreaVariants } from '@soybean-ui/variants';
 import type { ScrollAreaViewportProps } from './types';
@@ -12,10 +13,12 @@ const { class: cls, ...delegatedProps } = defineProps<ScrollAreaViewportProps>()
 const forwardedProps = useForwardProps(delegatedProps);
 
 const { viewport } = scrollAreaVariants();
+
+const mergedCls = computed(() => cn(viewport(), cls));
 </script>
 
 <template>
-  <ScrollAreaViewport v-bind="forwardedProps" :class="cn(viewport(), cls)">
+  <ScrollAreaViewport v-bind="forwardedProps" :class="mergedCls">
     <slot />
   </ScrollAreaViewport>
 </template>

--- a/packages/ui/src/components/scroll-area/scroll-area.vue
+++ b/packages/ui/src/components/scroll-area/scroll-area.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ScrollAreaCorner } from 'radix-vue';
+import { ScrollAreaCorner, useForwardProps } from 'radix-vue';
 import SScrollAreaRoot from './scroll-area-root.vue';
 import SScrollAreaViewport from './scroll-area-viewport.vue';
 import SScrollAreaScrollbar from './scroll-area-scrollbar.vue';
@@ -10,26 +10,18 @@ defineOptions({
   name: 'SScrollArea'
 });
 
-const {
-  class: rootClass,
-  type,
-  dir,
-  scrollHideDelay,
-  viewportClass,
-  nonce,
-  scrollbarClass,
-  orientation,
-  forceMount,
-  thumbClass
-} = defineProps<ScrollAreaProps>();
+const { viewportClass, nonce, scrollbarClass, orientation, forceMount, thumbClass, ...delegatedProps } =
+  defineProps<ScrollAreaProps>();
+
+const forwardedProps = useForwardProps(delegatedProps);
 </script>
 
 <template>
-  <SScrollAreaRoot :class="rootClass" :type="type" :dir="dir" :scroll-hide-delay="scrollHideDelay">
-    <SScrollAreaViewport :class="viewportClass" :nonce="nonce">
+  <SScrollAreaRoot v-bind="forwardedProps">
+    <SScrollAreaViewport :class="viewportClass" :nonce>
       <slot />
     </SScrollAreaViewport>
-    <SScrollAreaScrollbar :class="scrollbarClass" :orientation="orientation" :force-mount="forceMount">
+    <SScrollAreaScrollbar :class="scrollbarClass" :orientation :force-mount>
       <SScrollAreaThumb :class="thumbClass" />
     </SScrollAreaScrollbar>
     <ScrollAreaCorner />

--- a/packages/ui/src/components/scroll-area/types.ts
+++ b/packages/ui/src/components/scroll-area/types.ts
@@ -1,25 +1,17 @@
 import type {
-  ScrollAreaRootProps as $ScrollAreaRootProps,
-  ScrollAreaScrollbarProps as $ScrollAreaScrollbarProps,
-  ScrollAreaViewportProps as $ScrollAreaViewportProps
+  ScrollAreaRootProps as _ScrollAreaRootProps,
+  ScrollAreaScrollbarProps as _ScrollAreaScrollbarProps,
+  ScrollAreaViewportProps as _ScrollAreaViewportProps
 } from 'radix-vue';
-import type { ClassValue } from '../../types';
+import type { ClassValue, ClassValueProp } from '../../types';
 
-export type ScrollAreaRootProps = Omit<$ScrollAreaRootProps, 'as' | 'asChild'> & {
-  class?: ClassValue;
-};
+export type ScrollAreaRootProps = ClassValueProp & Omit<_ScrollAreaRootProps, 'as' | 'asChild'>;
 
-export type ScrollAreaViewportProps = Omit<$ScrollAreaViewportProps, 'as' | 'asChild'> & {
-  class?: ClassValue;
-};
+export type ScrollAreaViewportProps = ClassValueProp & Pick<_ScrollAreaViewportProps, 'nonce'>;
 
-export type ScrollAreaScrollbarProps = Omit<$ScrollAreaScrollbarProps, 'as' | 'asChild'> & {
-  class?: ClassValue;
-};
+export type ScrollAreaScrollbarProps = ClassValueProp & Pick<_ScrollAreaScrollbarProps, 'orientation' | 'forceMount'>;
 
-export type ScrollAreaThumbProps = {
-  class?: ClassValue;
-};
+export type ScrollAreaThumbProps = ClassValueProp;
 
 export type ScrollAreaProps = ScrollAreaRootProps &
   ScrollAreaViewportProps &

--- a/packages/ui/src/components/segment/segment-indicator-root.vue
+++ b/packages/ui/src/components/segment/segment-indicator-root.vue
@@ -10,11 +10,9 @@ defineOptions({
 
 const { class: cls } = defineProps<SegmentIndicatorRootProps>();
 
-const mergedCls = computed(() => {
-  const { indicatorRoot } = segmentVariants();
+const { indicatorRoot } = segmentVariants();
 
-  return cn(indicatorRoot(), cls);
-});
+const mergedCls = computed(() => cn(indicatorRoot(), cls));
 </script>
 
 <template>

--- a/packages/ui/src/components/segment/segment-indicator.vue
+++ b/packages/ui/src/components/segment/segment-indicator.vue
@@ -10,11 +10,9 @@ defineOptions({
 
 const { class: cls } = defineProps<SegmentIndicatorProps>();
 
-const mergedCls = computed(() => {
-  const { indicator } = segmentVariants();
+const { indicator } = segmentVariants();
 
-  return cn(indicator(), cls);
-});
+const mergedCls = computed(() => cn(indicator(), cls));
 </script>
 
 <template>

--- a/packages/ui/src/components/segment/segment-root.vue
+++ b/packages/ui/src/components/segment/segment-root.vue
@@ -11,11 +11,11 @@ const { activationMode = 'manual', ...delegatedProps } = defineProps<SegmentRoot
 
 const emit = defineEmits<SegmentRootEmits<T>>();
 
-const forwardedProps = useForwardPropsEmits(delegatedProps, emit);
+const forwarded = useForwardPropsEmits(delegatedProps, emit);
 </script>
 
 <template>
-  <TabsRoot v-bind="forwardedProps" :activation-mode="activationMode">
+  <TabsRoot v-bind="forwarded" :activation-mode>
     <slot />
   </TabsRoot>
 </template>

--- a/packages/ui/src/components/segment/segment-trigger-root.vue
+++ b/packages/ui/src/components/segment/segment-trigger-root.vue
@@ -12,11 +12,9 @@ const { class: cls, ...delegatedProps } = defineProps<SegmentTriggerRootProps>()
 
 const forwardedProps = useForwardProps(delegatedProps);
 
-const mergedCls = computed(() => {
-  const { triggerRoot } = segmentVariants();
+const { triggerRoot } = segmentVariants();
 
-  return cn(triggerRoot(), cls);
-});
+const mergedCls = computed(() => cn(triggerRoot(), cls));
 </script>
 
 <template>

--- a/packages/ui/src/components/segment/segment-trigger.vue
+++ b/packages/ui/src/components/segment/segment-trigger.vue
@@ -12,11 +12,9 @@ const { class: cls, ...delegatedProps } = defineProps<SegmentTriggerProps>();
 
 const forwardedProps = useForwardProps(delegatedProps);
 
-const mergedCls = computed(() => {
-  const { trigger } = segmentVariants();
+const { trigger } = segmentVariants();
 
-  return cn(trigger(), cls);
-});
+const mergedCls = computed(() => cn(trigger(), cls));
 </script>
 
 <template>

--- a/packages/ui/src/components/segment/segment.vue
+++ b/packages/ui/src/components/segment/segment.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts" generic="T extends SegmentOption = SegmentOption">
 import { useForwardPropsEmits } from 'radix-vue';
-import type { TabsRootEmits } from 'radix-vue';
 import SSegmentRoot from './segment-root.vue';
 import SSegmentTriggerRoot from './segment-trigger-root.vue';
 import SSegmentTrigger from './segment-trigger.vue';
 import SSegmentIndicatorRoot from './segment-indicator-root.vue';
 import SSegmentIndicator from './segment-indicator.vue';
-import type { SegmentOption, SegmentProps } from './types';
+import type { SegmentEmits, SegmentOption, SegmentProps } from './types';
 
 defineOptions({
   name: 'SSegment'
@@ -23,14 +22,14 @@ const {
   //
 } = defineProps<SegmentProps<T>>();
 
-const emit = defineEmits<TabsRootEmits<T['value']>>();
+const emit = defineEmits<SegmentEmits<T['value']>>();
 
 const forwarded = useForwardPropsEmits(delegatedRootProps, emit);
 </script>
 
 <template>
   <SSegmentRoot v-bind="forwarded">
-    <SSegmentTriggerRoot :class="triggerRootClass" :loop="loop">
+    <SSegmentTriggerRoot :class="triggerRootClass" :loop>
       <SSegmentTrigger
         v-for="item in options"
         :key="item.value"
@@ -40,9 +39,9 @@ const forwarded = useForwardPropsEmits(delegatedRootProps, emit);
       >
         <slot name="trigger" v-bind="{ ...item, active: item.value === modelValue }">{{ item.label }}</slot>
       </SSegmentTrigger>
-      <SSegmentIndicatorRoot :class="indicatorRootClass" :orientation="orientation">
+      <SSegmentIndicatorRoot :class="indicatorRootClass" :orientation>
         <slot name="indicator">
-          <SSegmentIndicator :class="indicatorClass" :orientation="orientation" />
+          <SSegmentIndicator :class="indicatorClass" :orientation />
         </slot>
       </SSegmentIndicatorRoot>
     </SSegmentTriggerRoot>

--- a/packages/ui/src/components/segment/types.ts
+++ b/packages/ui/src/components/segment/types.ts
@@ -1,25 +1,16 @@
 import type { TabsRootEmits as SegmentRootEmits, TabsListProps, TabsRootProps, TabsTriggerProps } from 'radix-vue';
-import type { ClassValue, StringOrNumber } from '../../types';
+import type { ClassValue, ClassValueProp, StringOrNumber } from '../../types';
 
-export type SegmentRootProps<T extends StringOrNumber = StringOrNumber> = Omit<TabsRootProps<T>, 'as' | 'asChild'> & {
-  class?: ClassValue;
-};
+export type SegmentRootProps<T extends StringOrNumber = StringOrNumber> = ClassValueProp &
+  Omit<TabsRootProps<T>, 'as' | 'asChild'>;
 
-export type SegmentTriggerRootProps = Omit<TabsListProps, 'as' | 'asChild'> & {
-  class?: ClassValue;
-};
+export type SegmentTriggerRootProps = ClassValueProp & Pick<TabsListProps, 'loop'>;
 
-export type SegmentTriggerProps = Omit<TabsTriggerProps, 'as' | 'asChild'> & {
-  class?: ClassValue;
-};
+export type SegmentTriggerProps = ClassValueProp & Pick<TabsTriggerProps, 'value' | 'disabled'>;
 
-export type SegmentIndicatorRootProps = {
-  class?: ClassValue;
-};
+export type SegmentIndicatorRootProps = ClassValueProp;
 
-export type SegmentIndicatorProps = {
-  class?: ClassValue;
-};
+export type SegmentIndicatorProps = ClassValueProp;
 
 export type SegmentOption<T extends StringOrNumber = StringOrNumber> = Pick<SegmentTriggerProps, 'disabled'> & {
   value: T;
@@ -34,5 +25,7 @@ export type SegmentProps<T extends SegmentOption> = SegmentRootProps<T['value']>
     indicatorRootClass?: ClassValue;
     indicatorClass?: ClassValue;
   };
+
+export type SegmentEmits<T extends StringOrNumber = StringOrNumber> = SegmentRootEmits<T>;
 
 export type { SegmentRootEmits };

--- a/packages/ui/src/components/select/select-content.vue
+++ b/packages/ui/src/components/select/select-content.vue
@@ -1,36 +1,34 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { SelectContent, useForwardPropsEmits } from 'radix-vue';
-import type { SelectContentEmits } from 'radix-vue';
 import { cn, selectVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
-import type { SelectContentProps } from './types';
+import type { SelectContentEmits, SelectContentProps } from './types';
 
 defineOptions({
   name: 'SSelectContent'
 });
 
-const props = withDefaults(defineProps<SelectContentProps>(), {
-  avoidCollisions: true,
-  prioritizePosition: true,
-  position: 'popper'
-});
+const {
+  class: cls,
+  avoidCollisions = true,
+  prioritizePosition = true,
+  position = 'popper',
+  ...delegatedProps
+} = defineProps<SelectContentProps>();
 
 const emit = defineEmits<SelectContentEmits>();
 
-const delegatedProps = computedOmit(props, ['class']);
-
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 
-const cls = computed(() => {
-  const { content } = selectVariants({ position: props.position });
+const mergedCls = computed(() => {
+  const { content } = selectVariants({ position });
 
-  return cn(content(), props.class);
+  return cn(content(), cls);
 });
 </script>
 
 <template>
-  <SelectContent v-bind="forwarded" :class="cls">
+  <SelectContent v-bind="forwarded" :class="mergedCls" :avoid-collisions :prioritize-position :position>
     <slot />
   </SelectContent>
 </template>

--- a/packages/ui/src/components/select/select-icon.vue
+++ b/packages/ui/src/components/select/select-icon.vue
@@ -1,30 +1,25 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { SelectIcon, useForwardProps } from 'radix-vue';
+import { SelectIcon } from 'radix-vue';
 import { ChevronsUpDown } from 'lucide-vue-next';
 import { cn, selectVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { SelectIconProps } from './types';
 
 defineOptions({
   name: 'SSelectIcon'
 });
 
-const props = defineProps<SelectIconProps>();
+const { class: cls, size } = defineProps<SelectIconProps>();
 
-const delegatedProps = computedOmit(props, ['class', 'size']);
+const mergedCls = computed(() => {
+  const { icon } = selectVariants({ size });
 
-const forwardedProps = useForwardProps(delegatedProps);
-
-const cls = computed(() => {
-  const { icon } = selectVariants({ size: props.size });
-
-  return cn(icon(), props.class);
+  return cn(icon(), cls);
 });
 </script>
 
 <template>
-  <SelectIcon v-bind="forwardedProps" :class="cls">
+  <SelectIcon :class="mergedCls">
     <slot>
       <ChevronsUpDown />
     </slot>

--- a/packages/ui/src/components/select/select-item-indicator.vue
+++ b/packages/ui/src/components/select/select-item-indicator.vue
@@ -1,30 +1,25 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { SelectItemIndicator, useForwardProps } from 'radix-vue';
+import { SelectItemIndicator } from 'radix-vue';
 import { Check } from 'lucide-vue-next';
 import { cn, selectVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { SelectItemIndicatorProps } from './types';
 
 defineOptions({
   name: 'SSelectItemIndicator'
 });
 
-const props = defineProps<SelectItemIndicatorProps>();
+const { class: cls, size } = defineProps<SelectItemIndicatorProps>();
 
-const delegatedProps = computedOmit(props, ['class']);
+const mergedCls = computed(() => {
+  const { itemIndicator } = selectVariants({ size });
 
-const forwardedProps = useForwardProps(delegatedProps);
-
-const cls = computed(() => {
-  const { itemIndicator } = selectVariants({ size: props.size });
-
-  return cn(itemIndicator(), props.class);
+  return cn(itemIndicator(), cls);
 });
 </script>
 
 <template>
-  <SelectItemIndicator v-bind="forwardedProps" :class="cls">
+  <SelectItemIndicator :class="mergedCls">
     <slot>
       <Check />
     </slot>

--- a/packages/ui/src/components/select/select-item-option.vue
+++ b/packages/ui/src/components/select/select-item-option.vue
@@ -16,13 +16,13 @@ defineProps<SelectItemOptionProps>();
   <SSelectItem
     :key="option.value"
     :value="option.value"
-    :size="size"
+    :size
     :text-value="option.label"
     :disabled="option.disabled"
     :class="itemClass"
   >
     <SelectItemText :class="itemTextClass">{{ option.label }}</SelectItemText>
-    <SSelectItemIndicator :class="itemIndicatorClass" :size="size">
+    <SSelectItemIndicator :class="itemIndicatorClass" :size>
       <slot name="itemIndicatorIcon" />
     </SSelectItemIndicator>
   </SSelectItem>

--- a/packages/ui/src/components/select/select-item.vue
+++ b/packages/ui/src/components/select/select-item.vue
@@ -2,28 +2,25 @@
 import { computed } from 'vue';
 import { SelectItem, useForwardProps } from 'radix-vue';
 import { cn, selectVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { SelectItemProps } from './types';
 
 defineOptions({
   name: 'SSelectItem'
 });
 
-const props = defineProps<SelectItemProps>();
-
-const delegatedProps = computedOmit(props, ['class', 'size']);
+const { class: cls, size, ...delegatedProps } = defineProps<SelectItemProps>();
 
 const forwardedProps = useForwardProps(delegatedProps);
 
-const cls = computed(() => {
-  const { item } = selectVariants({ size: props.size });
+const mergedCls = computed(() => {
+  const { item } = selectVariants({ size });
 
-  return cn(item(), props.class);
+  return cn(item(), cls);
 });
 </script>
 
 <template>
-  <SelectItem v-bind="forwardedProps" :class="cls">
+  <SelectItem v-bind="forwardedProps" :class="mergedCls">
     <slot />
   </SelectItem>
 </template>

--- a/packages/ui/src/components/select/select-label.vue
+++ b/packages/ui/src/components/select/select-label.vue
@@ -1,29 +1,24 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { SelectLabel, useForwardProps } from 'radix-vue';
+import { SelectLabel } from 'radix-vue';
 import { cn, selectVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { SelectLabelProps } from './types';
 
 defineOptions({
   name: 'SSelectLabel'
 });
 
-const props = defineProps<SelectLabelProps>();
+const { class: cls, size, for: id } = defineProps<SelectLabelProps>();
 
-const delegatedProps = computedOmit(props, ['class']);
+const mergedCls = computed(() => {
+  const { label } = selectVariants({ size });
 
-const forwardedProps = useForwardProps(delegatedProps);
-
-const cls = computed(() => {
-  const { label } = selectVariants({ size: props.size });
-
-  return cn(label(), props.class);
+  return cn(label(), cls);
 });
 </script>
 
 <template>
-  <SelectLabel v-bind="forwardedProps" :class="cls">
+  <SelectLabel :class="mergedCls" :for="id">
     <slot />
   </SelectLabel>
 </template>

--- a/packages/ui/src/components/select/select-scroll-down-button.vue
+++ b/packages/ui/src/components/select/select-scroll-down-button.vue
@@ -1,30 +1,25 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { SelectScrollDownButton, useForwardProps } from 'radix-vue';
+import { SelectScrollDownButton } from 'radix-vue';
 import { ChevronDown } from 'lucide-vue-next';
 import { cn, selectVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { SelectScrollDownButtonProps } from './types';
 
 defineOptions({
   name: 'SSelectScrollDownButton'
 });
 
-const props = defineProps<SelectScrollDownButtonProps>();
+const { class: cls, size } = defineProps<SelectScrollDownButtonProps>();
 
-const delegatedProps = computedOmit(props, ['class']);
+const mergedCls = computed(() => {
+  const { scrollDownButton } = selectVariants({ size });
 
-const forwardedProps = useForwardProps(delegatedProps);
-
-const cls = computed(() => {
-  const { scrollDownButton } = selectVariants({ size: props.size });
-
-  return cn(scrollDownButton(), props.class);
+  return cn(scrollDownButton(), cls);
 });
 </script>
 
 <template>
-  <SelectScrollDownButton v-bind="forwardedProps" :class="cls">
+  <SelectScrollDownButton :class="mergedCls">
     <slot>
       <ChevronDown />
     </slot>

--- a/packages/ui/src/components/select/select-scroll-up-button.vue
+++ b/packages/ui/src/components/select/select-scroll-up-button.vue
@@ -1,30 +1,25 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { SelectScrollUpButton, useForwardProps } from 'radix-vue';
+import { SelectScrollUpButton } from 'radix-vue';
 import { ChevronUp } from 'lucide-vue-next';
 import { cn, selectVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { SelectScrollUpButtonProps } from './types';
 
 defineOptions({
   name: 'SSelectScrollUpButton'
 });
 
-const props = defineProps<SelectScrollUpButtonProps>();
+const { class: cls, size } = defineProps<SelectScrollUpButtonProps>();
 
-const delegatedProps = computedOmit(props, ['class']);
+const mergedCls = computed(() => {
+  const { scrollUpButton } = selectVariants({ size });
 
-const forwardedProps = useForwardProps(delegatedProps);
-
-const cls = computed(() => {
-  const { scrollUpButton } = selectVariants({ size: props.size });
-
-  return cn(scrollUpButton(), props.class);
+  return cn(scrollUpButton(), cls);
 });
 </script>
 
 <template>
-  <SelectScrollUpButton v-bind="forwardedProps" :class="cls">
+  <SelectScrollUpButton :class="mergedCls">
     <slot>
       <ChevronUp />
     </slot>

--- a/packages/ui/src/components/select/select-separator.vue
+++ b/packages/ui/src/components/select/select-separator.vue
@@ -1,24 +1,22 @@
 <script setup lang="ts">
-import { SelectSeparator, useForwardProps } from 'radix-vue';
+import { computed } from 'vue';
+import { SelectSeparator } from 'radix-vue';
 import { cn, selectVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { SelectSeparatorProps } from './types';
 
 defineOptions({
   name: 'SSelectSeparator'
 });
 
-const props = defineProps<SelectSeparatorProps>();
-
-const delegatedProps = computedOmit(props, ['class']);
-
-const forwardedProps = useForwardProps(delegatedProps);
+const { class: cls } = defineProps<SelectSeparatorProps>();
 
 const { separator } = selectVariants();
+
+const mergedCls = computed(() => cn(separator(), cls));
 </script>
 
 <template>
-  <SelectSeparator v-bind="forwardedProps" :class="cn(separator(), props.class)" />
+  <SelectSeparator :class="mergedCls" />
 </template>
 
 <style scoped></style>

--- a/packages/ui/src/components/select/select-trigger.vue
+++ b/packages/ui/src/components/select/select-trigger.vue
@@ -1,29 +1,24 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { SelectTrigger, useForwardProps } from 'radix-vue';
+import { SelectTrigger } from 'radix-vue';
 import { cn, selectVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { SelectTriggerProps } from './types';
 
 defineOptions({
   name: 'SSelectTrigger'
 });
 
-const props = defineProps<SelectTriggerProps>();
+const { class: cls, size, disabled } = defineProps<SelectTriggerProps>();
 
-const delegatedProps = computedOmit(props, ['class', 'size']);
+const mergedCls = computed(() => {
+  const { trigger } = selectVariants({ size });
 
-const forwardedProps = useForwardProps(delegatedProps);
-
-const cls = computed(() => {
-  const { trigger } = selectVariants({ size: props.size });
-
-  return cn(trigger(), props.class);
+  return cn(trigger(), cls);
 });
 </script>
 
 <template>
-  <SelectTrigger v-bind="forwardedProps" :class="cls">
+  <SelectTrigger :class="mergedCls" :disabled>
     <slot />
   </SelectTrigger>
 </template>

--- a/packages/ui/src/components/select/select-viewport.vue
+++ b/packages/ui/src/components/select/select-viewport.vue
@@ -1,29 +1,24 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { SelectViewport, useForwardProps } from 'radix-vue';
+import { SelectViewport } from 'radix-vue';
 import { cn, selectVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { SelectViewportProps } from './types';
 
 defineOptions({
   name: 'SSelectViewport'
 });
 
-const props = defineProps<SelectViewportProps>();
+const { class: cls, position, nonce } = defineProps<SelectViewportProps>();
 
-const delegatedProps = computedOmit(props, ['class', 'position']);
+const mergedCls = computed(() => {
+  const { viewport } = selectVariants({ position });
 
-const forwardedProps = useForwardProps(delegatedProps);
-
-const cls = computed(() => {
-  const { viewport } = selectVariants({ position: props.position });
-
-  return cn(viewport(), props.class);
+  return cn(viewport(), cls);
 });
 </script>
 
 <template>
-  <SelectViewport v-bind="forwardedProps" :class="cls">
+  <SelectViewport :class="mergedCls" :nonce>
     <slot />
   </SelectViewport>
 </template>

--- a/packages/ui/src/components/select/select.vue
+++ b/packages/ui/src/components/select/select.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { SelectGroup, SelectPortal, SelectRoot, SelectValue, useForwardPropsEmits } from 'radix-vue';
-import type { SelectContentEmits, SelectRootEmits } from 'radix-vue';
 import { computedPick } from '../../shared';
 import SSelectContent from './select-content.vue';
 import SSelectTrigger from './select-trigger.vue';
@@ -11,20 +10,17 @@ import SSelectLabel from './select-label.vue';
 import SSelectScrollUpButton from './select-scroll-up-button.vue';
 import SSelectScrollDownButton from './select-scroll-down-button.vue';
 import SSelectItemOption from './select-item-option.vue';
-import type { SelectGroupOption, SelectOption, SelectProps } from './types';
+import type { SelectEmits, SelectGroupOption, SelectOption, SelectProps } from './types';
 
 defineOptions({
   name: 'SSelect'
 });
 
-const props = withDefaults(defineProps<SelectProps>(), {
-  avoidCollisions: true,
-  prioritizePosition: true
-});
+const { avoidCollisions = true, prioritizePosition = true, ...delegatedProps } = defineProps<SelectProps>();
 
-const emit = defineEmits<SelectRootEmits & SelectContentEmits>();
+const emit = defineEmits<SelectEmits>();
 
-const delegatedRootProps = computedPick(props, [
+const delegatedRootProps = computedPick(delegatedProps, [
   'defaultOpen',
   'open',
   'defaultValue',
@@ -38,21 +34,19 @@ const delegatedRootProps = computedPick(props, [
 
 const forwarded = useForwardPropsEmits(delegatedRootProps, emit);
 
-const delegatedContentProps = computedPick(props, [
+const delegatedContentProps = computedPick(delegatedProps, [
   'position',
   'bodyLock',
   'side',
   'sideOffset',
   'align',
   'alignOffset',
-  'avoidCollisions',
   'collisionBoundary',
   'collisionPadding',
   'arrowPadding',
   'sticky',
   'hideWhenDetached',
-  'updatePositionStrategy',
-  'prioritizePosition'
+  'updatePositionStrategy'
 ]);
 
 function isGroup(opt: SelectOption | SelectGroupOption): opt is SelectGroupOption {
@@ -62,28 +56,30 @@ function isGroup(opt: SelectOption | SelectGroupOption): opt is SelectGroupOptio
 
 <template>
   <SelectRoot v-bind="forwarded">
-    <SSelectTrigger :class="triggerClass" :size="size">
-      <SelectValue :placeholder="placeholder" />
-      <SSelectIcon :class="triggerIconClass" :size="size">
+    <SSelectTrigger :class="triggerClass" :size>
+      <SelectValue :placeholder />
+      <SSelectIcon :class="triggerIconClass" :size>
         <slot name="triggerIcon" />
       </SSelectIcon>
     </SSelectTrigger>
-    <SelectPortal :to="to" :disabled="disabledPortal" :force-mount="forceMountPortal">
+    <SelectPortal :to :disabled="disabledPortal" :force-mount="forceMountPortal">
       <SSelectContent
         :class="contentClass"
         v-bind="delegatedContentProps"
         :force-mount="forceMountContent"
+        :avoid-collisions
+        :prioritize-position
         @close-auto-focus="emit('closeAutoFocus', $event)"
         @escape-key-down="emit('escapeKeyDown', $event)"
         @pointer-down-outside="emit('pointerDownOutside', $event)"
       >
-        <SSelectScrollUpButton :size="size" :class="scrollUpButtonClass">
+        <SSelectScrollUpButton :size :class="scrollUpButtonClass">
           <slot name="scrollUpIcon" />
         </SSelectScrollUpButton>
-        <SSelectViewport :nonce="nonce" :position="position">
+        <SSelectViewport :nonce :position>
           <template v-for="(opt, index) in options">
             <template v-if="isGroup(opt)">
-              <SSelectLabel :key="`groupLabel_${opt.label}`" :size="size" :class="groupLabelClass">
+              <SSelectLabel :key="`groupLabel_${opt.label}`" :size :class="groupLabelClass">
                 {{ opt.label }}
               </SSelectLabel>
               <SSelectSeparator
@@ -95,12 +91,12 @@ function isGroup(opt: SelectOption | SelectGroupOption): opt is SelectGroupOptio
                 <template v-for="(item, itemIndex) in opt.options" :key="itemIndex">
                   <SSelectItemOption
                     :option="item"
-                    :size="size"
-                    :item-class="itemClass"
-                    :item-text-class="itemTextClass"
-                    :item-indicator-class="itemIndicatorClass"
+                    :size
+                    :item-class
+                    :item-text-class
+                    :item-indicator-class
                     :separator="itemIndex !== opt.options.length - 1 && (separator || item.separator)"
-                    :separator-class="separatorClass"
+                    :separator-class
                   >
                     <slot name="itemIndicatorIcon" />
                   </SSelectItemOption>
@@ -112,18 +108,18 @@ function isGroup(opt: SelectOption | SelectGroupOption): opt is SelectGroupOptio
                 :key="opt.value"
                 :option="opt"
                 :size="size"
-                :item-class="itemClass"
-                :item-text-class="itemTextClass"
-                :item-indicator-class="itemIndicatorClass"
+                :item-class
+                :item-text-class
+                :item-indicator-class
                 :separator="index !== options.length - 1 && (separator || opt.separator)"
-                :separator-class="separatorClass"
+                :separator-class
               >
                 <slot name="itemIndicatorIcon" />
               </SSelectItemOption>
             </template>
           </template>
         </SSelectViewport>
-        <SSelectScrollDownButton :size="size">
+        <SSelectScrollDownButton :size>
           <slot name="scrollDownIcon" />
         </SSelectScrollDownButton>
       </SSelectContent>

--- a/packages/ui/src/components/select/types.ts
+++ b/packages/ui/src/components/select/types.ts
@@ -1,64 +1,58 @@
 import type {
-  SelectContentProps as $SelectContentProps,
-  SelectItemProps as $SelectItemProps,
-  SelectLabelProps as $SelectLabelProps,
-  SelectTriggerProps as $SelectTriggerProps,
-  SelectViewportProps as $SelectViewportProps,
+  SelectContentEmits,
   SelectPortalProps,
-  SelectRootProps
+  SelectRootEmits,
+  SelectRootProps,
+  SelectContentProps as _SelectContentProps,
+  SelectItemProps as _SelectItemProps,
+  SelectLabelProps as _SelectLabelProps,
+  SelectTriggerProps as _SelectTriggerProps,
+  SelectViewportProps as _SelectViewportProps
 } from 'radix-vue';
 import type { SelectPosition, ThemeSize } from '@soybean-ui/variants';
-import type { ClassValue } from '../../types';
+import type { ClassValue, ClassValueProp } from '../../types';
 
-export type SelectContentProps = $SelectContentProps & {
-  class?: ClassValue;
-};
+export type SelectContentProps = ClassValueProp & Omit<_SelectContentProps, 'as' | 'asChild'>;
 
-export type SelectTriggerProps = $SelectTriggerProps & {
-  class?: ClassValue;
+export type SelectTriggerProps = ClassValueProp &
+  Pick<_SelectTriggerProps, 'disabled'> & {
+    size?: ThemeSize;
+  };
+
+export type SelectViewportProps = ClassValueProp &
+  Pick<_SelectViewportProps, 'nonce'> & {
+    position?: SelectPosition;
+  };
+
+export type SelectItemProps = ClassValueProp &
+  Omit<_SelectItemProps, 'as' | 'asChild'> & {
+    size?: ThemeSize;
+  };
+
+export type SelectItemIndicatorProps = ClassValueProp & {
   size?: ThemeSize;
 };
 
-export type SelectViewportProps = $SelectViewportProps & {
-  class?: ClassValue;
-  position?: SelectPosition;
-};
-
-export type SelectItemProps = $SelectItemProps & {
-  class?: ClassValue;
+export type SelectIconProps = ClassValueProp & {
   size?: ThemeSize;
 };
 
-export type SelectItemIndicatorProps = {
-  class?: ClassValue;
+export type SelectSeparatorProps = ClassValueProp;
+
+export type SelectLabelProps = ClassValueProp &
+  Pick<_SelectLabelProps, 'for'> & {
+    size?: ThemeSize;
+  };
+
+export type SelectScrollUpButtonProps = ClassValueProp & {
   size?: ThemeSize;
 };
 
-export type SelectIconProps = {
-  class?: ClassValue;
+export type SelectScrollDownButtonProps = ClassValueProp & {
   size?: ThemeSize;
 };
 
-export type SelectSeparatorProps = {
-  class?: ClassValue;
-};
-
-export type SelectLabelProps = $SelectLabelProps & {
-  class?: ClassValue;
-  size?: ThemeSize;
-};
-
-export type SelectScrollUpButtonProps = {
-  class?: ClassValue;
-  size?: ThemeSize;
-};
-
-export type SelectScrollDownButtonProps = {
-  class?: ClassValue;
-  size?: ThemeSize;
-};
-
-export type SelectOption = Pick<$SelectItemProps, 'value' | 'disabled' | 'textValue'> & {
+export type SelectOption = Pick<SelectItemProps, 'value' | 'disabled' | 'textValue'> & {
   /**
    * The label to display in the dropdown.
    *
@@ -77,7 +71,7 @@ export type SelectGroupOption = {
 
 export type SelectProps = SelectRootProps &
   Pick<SelectPortalProps, 'to'> &
-  Omit<SelectContentProps, 'as' | 'asChild' | 'forceMount' | 'class'> &
+  Omit<SelectContentProps, 'class' | 'forceMount'> &
   Pick<SelectViewportProps, 'nonce'> & {
     options: (SelectOption | SelectGroupOption)[];
     size?: ThemeSize;
@@ -103,4 +97,6 @@ export type SelectItemOptionProps = {
   option: SelectOption;
 } & Pick<SelectProps, 'size' | 'itemClass' | 'itemTextClass' | 'itemIndicatorClass' | 'separator' | 'separatorClass'>;
 
-export type { SelectPosition };
+export type SelectEmits = SelectRootEmits & SelectContentEmits;
+
+export type { SelectPosition, SelectContentEmits };

--- a/packages/ui/src/components/separator/separator-label.vue
+++ b/packages/ui/src/components/separator/separator-label.vue
@@ -8,19 +8,17 @@ defineOptions({
   name: 'SSeparatorLabel'
 });
 
-const props = defineProps<SeparatorLabelProps>();
+const { class: cls, align, orientation } = defineProps<SeparatorLabelProps>();
 
-const cls = computed(() => {
-  const { align, orientation } = props;
-
+const mergedCls = computed(() => {
   const { label } = separatorVariants({ align, orientation });
 
-  return cn(label(), props.class);
+  return cn(label(), cls);
 });
 </script>
 
 <template>
-  <Primitive as="span" :class="cls">
+  <Primitive as="span" :class="mergedCls">
     <slot />
   </Primitive>
 </template>

--- a/packages/ui/src/components/separator/separator-root.vue
+++ b/packages/ui/src/components/separator/separator-root.vue
@@ -1,31 +1,24 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { Separator, useForwardProps } from 'radix-vue';
+import { Separator } from 'radix-vue';
 import { cn, separatorVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { SeparatorRootProps } from './types';
 
 defineOptions({
   name: 'SSeparatorRoot'
 });
 
-const props = defineProps<SeparatorRootProps>();
+const { class: cls, border, decorative, orientation } = defineProps<SeparatorRootProps>();
 
-const delegatedProps = computedOmit(props, ['class', 'border']);
-
-const forwardedProps = useForwardProps(delegatedProps);
-
-const cls = computed(() => {
-  const { orientation, border } = props;
-
+const mergedCls = computed(() => {
   const { root } = separatorVariants({ orientation, border });
 
-  return cn(root(), props.class);
+  return cn(root(), cls);
 });
 </script>
 
 <template>
-  <Separator v-bind="forwardedProps" :class="cls">
+  <Separator :class="mergedCls" :decorative :orientation>
     <slot />
   </Separator>
 </template>

--- a/packages/ui/src/components/separator/separator.vue
+++ b/packages/ui/src/components/separator/separator.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { useForwardProps } from 'radix-vue';
-import { computedOmit } from '../../shared';
 import SSeparatorRoot from './separator-root.vue';
 import SSeparatorLabel from './separator-label.vue';
 import type { SeparatorProps } from './types';
@@ -9,17 +8,15 @@ defineOptions({
   name: 'SSeparator'
 });
 
-const props = defineProps<SeparatorProps>();
+const { align, label, labelClass, ...delegatedProps } = defineProps<SeparatorProps>();
 
-const delegatedRootProps = computedOmit(props, ['align', 'label', 'labelClass']);
-
-const forwardedRootProps = useForwardProps(delegatedRootProps);
+const forwardedProps = useForwardProps(delegatedProps);
 </script>
 
 <template>
-  <SSeparatorRoot v-bind="forwardedRootProps">
+  <SSeparatorRoot v-bind="forwardedProps">
     <slot name="leading" />
-    <SSeparatorLabel v-if="label || $slots.default" :class="labelClass" :orientation="orientation" :align="align">
+    <SSeparatorLabel v-if="label || $slots.default" :class="labelClass" :align :orientation>
       <slot>{{ label }}</slot>
     </SSeparatorLabel>
     <slot name="trailing" />

--- a/packages/ui/src/components/separator/types.ts
+++ b/packages/ui/src/components/separator/types.ts
@@ -1,22 +1,21 @@
-import type { SeparatorProps as $SeparatorProps } from 'radix-vue';
+import type { SeparatorProps as _SeparatorProps } from 'radix-vue';
 import type { SeparatorBorder } from '@soybean-ui/variants';
-import type { ClassValue, ThemeAlign, ThemeOrientation } from '../../types';
+import type { ClassValue, ClassValueProp, ThemeAlign, ThemeOrientation } from '../../types';
 
-export type SeparatorRootProps = Pick<$SeparatorProps, 'orientation' | 'decorative'> & {
-  class?: ClassValue;
-  border?: SeparatorBorder;
-};
+export type SeparatorRootProps = ClassValueProp &
+  Pick<_SeparatorProps, 'orientation' | 'decorative'> & {
+    border?: SeparatorBorder;
+  };
 
-export type SeparatorLabelProps = {
-  class?: ClassValue;
+export type SeparatorLabelProps = ClassValueProp & {
   orientation?: ThemeOrientation;
   align?: ThemeAlign;
 };
 
-export type SeparatorProps = SeparatorRootProps & {
-  align?: ThemeAlign;
-  label?: string;
-  labelClass?: ClassValue;
-};
+export type SeparatorProps = SeparatorRootProps &
+  SeparatorLabelProps & {
+    label?: string;
+    labelClass?: ClassValue;
+  };
 
 export type { SeparatorBorder };

--- a/packages/ui/src/components/sheet/sheet-content.vue
+++ b/packages/ui/src/components/sheet/sheet-content.vue
@@ -64,11 +64,9 @@ const mergedCls = computed(() => {
   return cn(content(), cls);
 });
 
-const mergedFooterCls = computed(() => {
-  const { cardFooter } = sheetVariants();
+const { cardFooter } = sheetVariants();
 
-  return cn(cardFooter(), footerClass);
-});
+const mergedFooterCls = computed(() => cn(cardFooter(), footerClass));
 </script>
 
 <template>

--- a/packages/ui/src/components/sheet/sheet-overlay.vue
+++ b/packages/ui/src/components/sheet/sheet-overlay.vue
@@ -10,11 +10,9 @@ defineOptions({
 
 const { class: cls, forceMount } = defineProps<SheetOverlayProps>();
 
-const mergedCls = computed(() => {
-  const { overlay } = sheetVariants();
+const { overlay } = sheetVariants();
 
-  return cn(overlay(), cls);
-});
+const mergedCls = computed(() => cn(overlay(), cls));
 </script>
 
 <template>

--- a/packages/ui/src/components/sheet/types.ts
+++ b/packages/ui/src/components/sheet/types.ts
@@ -7,19 +7,17 @@ import type {
   DialogRootProps
 } from 'radix-vue';
 import type { SheetSide } from '@soybean-ui/variants';
-import type { ClassValue } from '../../types';
+import type { ClassValue, ClassValueProp } from '../../types';
 import type { CardProps } from '../card/types';
 
 export type SheetRootProps = DialogRootProps;
 
 export type SheetPortalProps = DialogPortalProps;
 
-export type SheetOverlayProps = Pick<DialogOverlayProps, 'forceMount'> & {
-  class?: ClassValue;
-};
+export type SheetOverlayProps = ClassValueProp & Pick<DialogOverlayProps, 'forceMount'>;
 
-export type SheetContentProps = Pick<DialogContentProps, 'forceMount' | 'trapFocus' | 'disableOutsidePointerEvents'> &
-  CardProps & {
+export type SheetContentProps = CardProps &
+  Pick<DialogContentProps, 'forceMount' | 'trapFocus' | 'disableOutsidePointerEvents'> & {
     side?: SheetSide;
     showClose?: boolean;
   };

--- a/packages/ui/src/components/switch/switch-root.vue
+++ b/packages/ui/src/components/switch/switch-root.vue
@@ -3,30 +3,27 @@ import { computed } from 'vue';
 import { SwitchRoot, useForwardPropsEmits } from 'radix-vue';
 import type { SwitchRootEmits } from 'radix-vue';
 import { cn, switchVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { SwitchRootProps } from './types';
 
 defineOptions({
   name: 'SSwitchRoot'
 });
 
-const props = defineProps<SwitchRootProps>();
-
-const delegatedProps = computedOmit(props, ['class', 'color', 'size']);
+const { class: cls, color, size, ...delegatedProps } = defineProps<SwitchRootProps>();
 
 const emit = defineEmits<SwitchRootEmits>();
 
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 
-const cls = computed(() => {
-  const { root } = switchVariants({ color: props.color, size: props.size });
+const mergedCls = computed(() => {
+  const { root } = switchVariants({ color, size });
 
-  return cn(root(), props.class);
+  return cn(root(), cls);
 });
 </script>
 
 <template>
-  <SwitchRoot :class="cls" v-bind="forwarded">
+  <SwitchRoot v-bind="forwarded" :class="mergedCls">
     <slot />
   </SwitchRoot>
 </template>

--- a/packages/ui/src/components/switch/switch-thumb.vue
+++ b/packages/ui/src/components/switch/switch-thumb.vue
@@ -8,17 +8,17 @@ defineOptions({
   name: 'SSwitchThumb'
 });
 
-const props = defineProps<SwitchThumbProps>();
+const { class: cls, size } = defineProps<SwitchThumbProps>();
 
-const cls = computed(() => {
-  const { thumb } = switchVariants({ size: props.size });
+const mergedCls = computed(() => {
+  const { thumb } = switchVariants({ size });
 
-  return cn(thumb(), props.class);
+  return cn(thumb(), cls);
 });
 </script>
 
 <template>
-  <SwitchThumb :class="cls">
+  <SwitchThumb :class="mergedCls">
     <slot />
   </SwitchThumb>
 </template>

--- a/packages/ui/src/components/switch/switch.vue
+++ b/packages/ui/src/components/switch/switch.vue
@@ -2,7 +2,6 @@
 import { computed, useId } from 'vue';
 import { useForwardPropsEmits } from 'radix-vue';
 import type { SwitchRootEmits } from 'radix-vue';
-import { computedOmit } from '../../shared';
 import SSwitchRoot from './switch-root.vue';
 import SSwitchThumb from './switch-thumb.vue';
 import type { SwitchProps } from './types';
@@ -11,22 +10,20 @@ defineOptions({
   name: 'SSwitch'
 });
 
-const props = defineProps<SwitchProps>();
+const { id, thumbClass, ...delegatedProps } = defineProps<SwitchProps>();
 
 const emit = defineEmits<SwitchRootEmits>();
-
-const delegatedProps = computedOmit(props, ['id', 'thumbClass']);
 
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 
 const defaultId = useId();
 
-const switchId = computed(() => props.id || `switch-${defaultId}`);
+const switchId = computed(() => id || `switch-${defaultId}`);
 </script>
 
 <template>
   <SSwitchRoot v-bind="forwarded" :id="switchId">
-    <SSwitchThumb :size="size" :class="thumbClass">
+    <SSwitchThumb :class="thumbClass" :size>
       <slot />
     </SSwitchThumb>
   </SSwitchRoot>

--- a/packages/ui/src/components/switch/types.ts
+++ b/packages/ui/src/components/switch/types.ts
@@ -1,15 +1,14 @@
-import type { SwitchRootProps as $SwitchRootProps } from 'radix-vue';
+import type { SwitchRootProps as _SwitchRootProps } from 'radix-vue';
 import type { ThemeColor, ThemeSize } from '@soybean-ui/variants';
-import type { ClassValue } from '../../types';
+import type { ClassValue, ClassValueProp } from '../../types';
 
-export type SwitchRootProps = $SwitchRootProps & {
-  class?: ClassValue;
-  color?: ThemeColor;
-  size?: ThemeSize;
-};
+export type SwitchRootProps = ClassValueProp &
+  Omit<_SwitchRootProps, 'as' | 'asChild'> & {
+    color?: ThemeColor;
+    size?: ThemeSize;
+  };
 
-export type SwitchThumbProps = {
-  class?: ClassValue;
+export type SwitchThumbProps = ClassValueProp & {
   size?: ThemeSize;
 };
 

--- a/packages/ui/src/components/tabs/tabs-content.vue
+++ b/packages/ui/src/components/tabs/tabs-content.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { TabsContent, useForwardProps } from 'radix-vue';
+import { TabsContent } from 'radix-vue';
 import { cn, tabsVariants } from '@soybean-ui/variants';
 import type { TabsContentProps } from './types';
 
@@ -8,9 +8,7 @@ defineOptions({
   name: 'STabsContent'
 });
 
-const { class: cls, orientation, ...delegatedProps } = defineProps<TabsContentProps>();
-
-const forwardedProps = useForwardProps(delegatedProps);
+const { class: cls, orientation, value, forceMount } = defineProps<TabsContentProps>();
 
 const mergedCls = computed(() => {
   const { content } = tabsVariants({ orientation });
@@ -20,7 +18,7 @@ const mergedCls = computed(() => {
 </script>
 
 <template>
-  <TabsContent v-bind="forwardedProps" :class="mergedCls">
+  <TabsContent :class="mergedCls" :value :force-mount>
     <slot />
   </TabsContent>
 </template>

--- a/packages/ui/src/components/tabs/tabs-list.vue
+++ b/packages/ui/src/components/tabs/tabs-list.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
-import { TabsList, useForwardProps } from 'radix-vue';
+import { TabsList } from 'radix-vue';
 import { cn, tabsVariants } from '@soybean-ui/variants';
 import type { TabsListProps } from './types';
 
@@ -8,9 +8,7 @@ defineOptions({
   name: 'STabsList'
 });
 
-const { class: cls, orientation, ...delegatedProps } = defineProps<TabsListProps>();
-
-const forwardedProps = useForwardProps(delegatedProps);
+const { class: cls, orientation, loop } = defineProps<TabsListProps>();
 
 const mergedCls = computed(() => {
   const { list } = tabsVariants({ orientation });
@@ -20,7 +18,7 @@ const mergedCls = computed(() => {
 </script>
 
 <template>
-  <TabsList v-bind="forwardedProps" :class="mergedCls">
+  <TabsList :class="mergedCls" :loop>
     <slot />
   </TabsList>
 </template>

--- a/packages/ui/src/components/tabs/tabs-root.vue
+++ b/packages/ui/src/components/tabs/tabs-root.vue
@@ -1,30 +1,29 @@
 <script setup lang="ts" generic="T extends StringOrNumber = StringOrNumber">
 import { computed } from 'vue';
 import { TabsRoot, useForwardPropsEmits } from 'radix-vue';
-import type { TabsRootEmits } from 'radix-vue';
 import { cn, tabsVariants } from '@soybean-ui/variants';
 import type { StringOrNumber } from '../../types';
-import type { TabsRootProps } from './types';
+import type { TabsRootEmits, TabsRootProps } from './types';
 
 defineOptions({
   name: 'STabsRoot'
 });
 
-const { class: cls, ...delegatedProps } = defineProps<TabsRootProps<T>>();
+const { class: cls, orientation, ...delegatedProps } = defineProps<TabsRootProps<T>>();
 
 const emit = defineEmits<TabsRootEmits<T>>();
 
 const forwardedProps = useForwardPropsEmits(delegatedProps, emit);
 
 const mergedCls = computed(() => {
-  const { root } = tabsVariants({ orientation: delegatedProps.orientation });
+  const { root } = tabsVariants({ orientation });
 
   return cn(root(), cls);
 });
 </script>
 
 <template>
-  <TabsRoot v-bind="forwardedProps" :class="mergedCls">
+  <TabsRoot v-bind="forwardedProps" :class="mergedCls" :orientation>
     <slot />
   </TabsRoot>
 </template>

--- a/packages/ui/src/components/tabs/tabs.vue
+++ b/packages/ui/src/components/tabs/tabs.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts" generic="T extends TabsOption = TabsOption">
 import { useForwardPropsEmits } from 'radix-vue';
-import type { TabsRootEmits } from 'radix-vue';
 import STabsRoot from './tabs-root.vue';
 import STabsList from './tabs-list.vue';
 import STabsTrigger from './tabs-trigger.vue';
 import STabsIndicatorRoot from './tabs-indicator-root.vue';
 import STabsIndicator from './tabs-indicator.vue';
 import STabsContent from './tabs-content.vue';
-import type { TabsOption, TabsProps } from './types';
+import type { TabsEmits, TabsOption, TabsProps } from './types';
 
 defineOptions({
   name: 'STabs'
@@ -26,27 +25,27 @@ const {
   ...delegatedRootProps
 } = defineProps<TabsProps<T>>();
 
-const emit = defineEmits<TabsRootEmits<T['value']>>();
+const emit = defineEmits<TabsEmits<T['value']>>();
 
 const forwarded = useForwardPropsEmits(delegatedRootProps, emit);
 </script>
 
 <template>
   <STabsRoot v-bind="forwarded">
-    <STabsList :class="listClass" :loop="loop" :orientation="orientation">
+    <STabsList :class="listClass" :loop :orientation>
       <STabsTrigger
         v-for="item in options"
         :key="item.value"
         :value="item.value"
         :disabled="item.disabled"
         :class="triggerClass"
-        :enable-indicator="enableIndicator"
+        :enable-indicator
       >
         <slot name="trigger" v-bind="{ ...item, active: item.value === modelValue }">{{ item.label }}</slot>
       </STabsTrigger>
-      <STabsIndicatorRoot v-if="enableIndicator" :class="indicatorRootClass" :orientation="orientation">
+      <STabsIndicatorRoot v-if="enableIndicator" :class="indicatorRootClass" :orientation>
         <slot name="indicator">
-          <STabsIndicator :class="indicatorClass" :orientation="orientation" />
+          <STabsIndicator :class="indicatorClass" :orientation />
         </slot>
       </STabsIndicatorRoot>
     </STabsList>
@@ -56,7 +55,7 @@ const forwarded = useForwardPropsEmits(delegatedRootProps, emit);
       :value="item.value"
       :force-mount="forceMountContent"
       :class="contentClass"
-      :orientation="orientation"
+      :orientation
     >
       <slot name="content" v-bind="{ ...item, active: item.value === modelValue }" />
     </STabsContent>

--- a/packages/ui/src/components/tabs/types.ts
+++ b/packages/ui/src/components/tabs/types.ts
@@ -1,40 +1,38 @@
 import type {
-  TabsContentProps as $TabsContentProps,
-  TabsListProps as $TabsListProps,
-  TabsRootProps as $TabsRootProps,
-  TabsTriggerProps as $TabsTriggerProps
+  TabsRootEmits,
+  TabsContentProps as _TabsContentProps,
+  TabsListProps as _TabsListProps,
+  TabsRootProps as _TabsRootProps,
+  TabsTriggerProps as _TabsTriggerProps
 } from 'radix-vue';
-import type { ClassValue, StringOrNumber, ThemeOrientation } from '../../types';
+import type { ClassValue, ClassValueProp, StringOrNumber, ThemeOrientation } from '../../types';
 
-export type TabsRootProps<T extends StringOrNumber = StringOrNumber> = Omit<$TabsRootProps<T>, 'as' | 'asChild'> & {
-  class?: ClassValue;
-};
+export type TabsRootProps<T extends StringOrNumber = StringOrNumber> = ClassValueProp &
+  Omit<_TabsRootProps<T>, 'as' | 'asChild'>;
 
-export type TabsListProps = Omit<$TabsListProps, 'as' | 'asChild'> & {
-  class?: ClassValue;
+export type TabsListProps = ClassValueProp &
+  Pick<_TabsListProps, 'loop'> & {
+    orientation?: ThemeOrientation;
+  };
+
+export type TabsTriggerProps = ClassValueProp &
+  Pick<_TabsTriggerProps, 'value' | 'disabled'> & {
+    orientation?: ThemeOrientation;
+    enableIndicator?: boolean;
+  };
+
+export type TabsIndicatorRootProps = ClassValueProp & {
   orientation?: ThemeOrientation;
 };
 
-export type TabsTriggerProps = Omit<$TabsTriggerProps, 'as' | 'asChild'> & {
-  class?: ClassValue;
-  orientation?: ThemeOrientation;
-  enableIndicator?: boolean;
-};
-
-export type TabsIndicatorRootProps = {
-  class?: ClassValue;
+export type TabsIndicatorProps = ClassValueProp & {
   orientation?: ThemeOrientation;
 };
 
-export type TabsIndicatorProps = {
-  class?: ClassValue;
-  orientation?: ThemeOrientation;
-};
-
-export type TabsContentProps = Omit<$TabsContentProps, 'as' | 'asChild'> & {
-  class?: ClassValue;
-  orientation?: ThemeOrientation;
-};
+export type TabsContentProps = ClassValueProp &
+  Pick<_TabsContentProps, 'value' | 'forceMount'> & {
+    orientation?: ThemeOrientation;
+  };
 
 export type TabsOption<T extends StringOrNumber = StringOrNumber> = Pick<TabsTriggerProps, 'disabled'> & {
   value: T;
@@ -52,3 +50,7 @@ export type TabsProps<T extends TabsOption> = TabsRootProps<T['value']> &
     forceMountContent?: boolean;
     contentClass?: ClassValue;
   };
+
+export type TabsEmits<T extends StringOrNumber = StringOrNumber> = TabsRootEmits<T>;
+
+export type { TabsRootEmits };

--- a/packages/ui/src/components/textarea/textarea-content.vue
+++ b/packages/ui/src/components/textarea/textarea-content.vue
@@ -2,27 +2,23 @@
 import { computed } from 'vue';
 import { Primitive, useForwardProps } from 'radix-vue';
 import { cn, textareaVariants } from '@soybean-ui/variants';
-import { computedOmit, isBlankString } from '../../shared';
+import { isBlankString } from '../../shared';
 import type { TextareaContentEmits, TextareaContentProps } from './types';
 
 defineOptions({
   name: 'STextareaContent'
 });
 
-const props = defineProps<TextareaContentProps>();
+const { class: cls, size, resize, modelValue, defaultValue, ...delegatedProps } = defineProps<TextareaContentProps>();
 
 const emit = defineEmits<TextareaContentEmits>();
 
-const delegatedProps = computedOmit(props, ['class', 'size', 'resize', 'modelValue', 'defaultValue']);
-
 const forwardedProps = useForwardProps(delegatedProps);
 
-const cls = computed(() => {
-  const resize = isBlankString(props.resize) ? true : props.resize;
+const mergedCls = computed(() => {
+  const { content } = textareaVariants({ size, resize: isBlankString(resize) || resize });
 
-  const { content } = textareaVariants({ size: props.size, resize });
-
-  return cn(content(), props.class);
+  return cn(content(), cls);
 });
 
 function handleInput(event: Event) {
@@ -35,7 +31,7 @@ function handleInput(event: Event) {
     as="textarea"
     v-bind="forwardedProps"
     :value="modelValue || defaultValue"
-    :class="cls"
+    :class="mergedCls"
     @input="handleInput"
   />
 </template>

--- a/packages/ui/src/components/textarea/textarea-count.vue
+++ b/packages/ui/src/components/textarea/textarea-count.vue
@@ -8,25 +8,25 @@ defineOptions({
   name: 'STextareaCount'
 });
 
-const props = defineProps<TextareaCountProps>();
+const { class: cls, size, value, maxlength, countGraphemes } = defineProps<TextareaCountProps>();
 
-const cls = computed(() => {
-  const { count } = textareaVariants({ size: props.size });
+const mergedCls = computed(() => {
+  const { count } = textareaVariants({ size });
 
-  return cn(count(), props.class);
+  return cn(count(), cls);
 });
 
 const count = computed(() => {
-  if (!props.value) {
+  if (!value) {
     return 0;
   }
 
-  return props.countGraphemes?.(props.value) || String(props.value).length;
+  return countGraphemes?.(value) || String(value).length;
 });
 
 const countWithMaxLength = computed(() => {
-  if (props.maxlength) {
-    return `${count.value} / ${props.maxlength}`;
+  if (maxlength) {
+    return `${count.value} / ${maxlength}`;
   }
 
   return count.value;
@@ -34,7 +34,7 @@ const countWithMaxLength = computed(() => {
 </script>
 
 <template>
-  <Primitive as="div" :class="cls">
+  <Primitive as="div" :class="mergedCls">
     <slot :count="count">{{ countWithMaxLength }}</slot>
   </Primitive>
 </template>

--- a/packages/ui/src/components/textarea/textarea-root.vue
+++ b/packages/ui/src/components/textarea/textarea-root.vue
@@ -8,17 +8,15 @@ defineOptions({
   name: 'STextareaRoot'
 });
 
-const props = defineProps<TextareaRootProps>();
+const { class: cls } = defineProps<TextareaRootProps>();
 
-const cls = computed(() => {
-  const { root } = textareaVariants();
+const { root } = textareaVariants();
 
-  return cn(root(), props.class);
-});
+const mergedCls = computed(() => cn(root(), cls));
 </script>
 
 <template>
-  <Primitive as="div" :class="cls">
+  <Primitive as="div" :class="mergedCls">
     <slot />
   </Primitive>
 </template>

--- a/packages/ui/src/components/textarea/textarea.vue
+++ b/packages/ui/src/components/textarea/textarea.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useForwardExpose, useForwardPropsEmits } from 'radix-vue';
-import { computedOmit } from '../../shared';
 import TextareaRoot from './textarea-root.vue';
 import STextareaContent from './textarea-content.vue';
 import STextareaCount from './textarea-count.vue';
@@ -11,38 +10,29 @@ defineOptions({
   name: 'STextarea'
 });
 
-const props = defineProps<TextareaProps>();
+const {
+  class: rootCls,
+  contentClass,
+  showCount,
+  countClass,
+  countGraphemes,
+  ...delegatedContentProps
+} = defineProps<TextareaProps>();
 
 const emit = defineEmits<TextareaContentEmits>();
 
 const { forwardRef } = useForwardExpose();
 
-const delegatedContentProps = computedOmit(props, [
-  'class',
-  'contentClass',
-  'showCount',
-  'countClass',
-  'countGraphemes'
-]);
-
 const forwardedContent = useForwardPropsEmits(delegatedContentProps, emit);
 
-const value = computed(() => props.modelValue || props.defaultValue);
+const value = computed(() => delegatedContentProps.modelValue || delegatedContentProps.defaultValue);
 </script>
 
 <template>
-  <TextareaRoot :class="props.class">
-    <STextareaContent :ref="forwardRef" v-bind="forwardedContent" :class="contentClass" />
-    <STextareaCount
-      v-if="showCount"
-      v-slot="{ count }"
-      :class="countClass"
-      :size="size"
-      :value="value"
-      :maxlength="maxlength"
-      :count-graphemes="countGraphemes"
-    >
-      <slot name="count" :count="count" :value="count" />
+  <TextareaRoot :class="rootCls">
+    <STextareaContent v-bind="forwardedContent" :ref="forwardRef" :class="contentClass" />
+    <STextareaCount v-if="showCount" v-slot="{ count }" :class="countClass" :size :value :maxlength :count-graphemes>
+      <slot name="count" :count :value />
     </STextareaCount>
   </TextareaRoot>
 </template>

--- a/packages/ui/src/components/textarea/types.ts
+++ b/packages/ui/src/components/textarea/types.ts
@@ -1,12 +1,9 @@
 import type { TextareaResize, ThemeSize } from '@soybean-ui/variants';
-import type { ClassValue } from '../../types';
+import type { ClassValue, ClassValueProp } from '../../types';
 
-export type TextareaRootProps = {
-  class?: ClassValue;
-};
+export type TextareaRootProps = ClassValueProp;
 
-export type TextareaContentProps = {
-  class?: ClassValue;
+export type TextareaContentProps = ClassValueProp & {
   modelValue?: string;
   defaultValue?: string;
   size?: ThemeSize;
@@ -34,10 +31,7 @@ export type TextareaContentEmits = {
   'update:modelValue': [value: string];
 };
 
-export type TextareaCountProps = {
-  class?: ClassValue;
-  size?: ThemeSize;
-  maxlength?: number | string;
+export type TextareaCountProps = Pick<TextareaContentProps, 'class' | 'size' | 'maxlength'> & {
   value?: string;
   countGraphemes?: (input: string) => number;
 };

--- a/packages/ui/src/components/toggle-group/toggle-group-item.vue
+++ b/packages/ui/src/components/toggle-group/toggle-group-item.vue
@@ -2,28 +2,25 @@
 import { computed } from 'vue';
 import { ToggleGroupItem, useForwardProps } from 'radix-vue';
 import { cn, toggleVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { ToggleGroupItemProps } from './types';
 
 defineOptions({
   name: 'SToggleGroupItem'
 });
 
-const props = defineProps<ToggleGroupItemProps>();
-
-const delegatedProps = computedOmit(props, ['class', 'variant', 'size']);
+const { class: cls, variant, size, ...delegatedProps } = defineProps<ToggleGroupItemProps>();
 
 const forwardedProps = useForwardProps(delegatedProps);
 
-const cls = computed(() => {
-  const { toggle } = toggleVariants({ variant: props.variant, size: props.size });
+const mergedCls = computed(() => {
+  const { toggle } = toggleVariants({ variant, size });
 
-  return cn(toggle(), props.class);
+  return cn(toggle(), cls);
 });
 </script>
 
 <template>
-  <ToggleGroupItem v-bind="forwardedProps" :class="cls">
+  <ToggleGroupItem v-bind="forwardedProps" :class="mergedCls">
     <slot />
   </ToggleGroupItem>
 </template>

--- a/packages/ui/src/components/toggle-group/toggle-group-root.vue
+++ b/packages/ui/src/components/toggle-group/toggle-group-root.vue
@@ -5,33 +5,29 @@
 >
 import { computed } from 'vue';
 import { ToggleGroupRoot, useForwardPropsEmits } from 'radix-vue';
-import type { ToggleGroupRootEmits } from 'radix-vue';
 import { cn, toggleVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { SingleOrMultipleType } from '../../types';
-import type { ToggleGroupRootProps } from './types';
+import type { ToggleGroupRootEmits, ToggleGroupRootProps } from './types';
 
 defineOptions({
   name: 'SToggleGroupRoot'
 });
 
-const props = defineProps<ToggleGroupRootProps<V, E>>();
+const { class: cls, size, ...delegatedProps } = defineProps<ToggleGroupRootProps<V, E>>();
 
-const emit = defineEmits<ToggleGroupRootEmits>();
-
-const delegatedProps = computedOmit(props, ['class']);
+const emit = defineEmits<ToggleGroupRootEmits<V>>();
 
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 
-const cls = computed(() => {
-  const { groupRoot } = toggleVariants({ size: props.size });
+const mergedCls = computed(() => {
+  const { groupRoot } = toggleVariants({ size });
 
-  return cn(groupRoot(), props.class);
+  return cn(groupRoot(), cls);
 });
 </script>
 
 <template>
-  <ToggleGroupRoot v-bind="forwarded" :class="cls">
+  <ToggleGroupRoot v-bind="forwarded" :class="mergedCls">
     <slot />
   </ToggleGroupRoot>
 </template>

--- a/packages/ui/src/components/toggle-group/toggle-group.vue
+++ b/packages/ui/src/components/toggle-group/toggle-group.vue
@@ -8,12 +8,10 @@
   "
 >
 import { useForwardPropsEmits } from 'radix-vue';
-import type { ToggleGroupRootEmits } from 'radix-vue';
-import { cn, toggleVariants } from '@soybean-ui/variants';
 import type { SingleOrMultipleType } from '../../types';
 import SToggleGroupRoot from './toggle-group-root.vue';
 import SToggleGroupItem from './toggle-group-item.vue';
-import type { ToggleGroupItemData, ToggleGroupProps } from './types';
+import type { ToggleGroupEmits, ToggleGroupItemData, ToggleGroupProps } from './types';
 
 defineOptions({
   name: 'SToggleGroup'
@@ -21,13 +19,13 @@ defineOptions({
 
 const props = defineProps<ToggleGroupProps<T, V, E>>();
 
-const emit = defineEmits<ToggleGroupRootEmits>();
+const emit = defineEmits<ToggleGroupEmits<V>>();
 
 const forwarded = useForwardPropsEmits(props, emit);
 </script>
 
 <template>
-  <SToggleGroupRoot v-bind="forwarded" :class="cn(toggleVariants({ variant, size }), props.class)">
+  <SToggleGroupRoot v-bind="forwarded">
     <SToggleGroupItem v-for="item in items" :key="item.value" :value="item.value" :disabled="item.disabled">
       <slot name="item" v-bind="item" />
     </SToggleGroupItem>

--- a/packages/ui/src/components/toggle-group/types.ts
+++ b/packages/ui/src/components/toggle-group/types.ts
@@ -1,23 +1,20 @@
 import type {
-  ToggleGroupItemProps as $ToggleGroupItemProps,
-  ToggleGroupRootProps as $ToggleGroupRootProps
+  ToggleGroupItemProps as _ToggleGroupItemProps,
+  ToggleGroupRootProps as _ToggleGroupRootProps
 } from 'radix-vue';
-import type { ThemeSize, ToggleVariant } from '@soybean-ui/variants';
-import type { ClassValue, SingleOrMultipleType } from '../../types';
+import type { ToggleVariant } from '@soybean-ui/variants';
+import type { ClassValueProp, SingleOrMultipleType, ThemeSize } from '../../types';
 
-export type ToggleGroupRootProps<
-  ValidValue = string | string[],
-  ExplicitType = SingleOrMultipleType
-> = $ToggleGroupRootProps<ValidValue, ExplicitType> & {
-  class?: ClassValue;
-  size?: ThemeSize;
-};
+export type ToggleGroupRootProps<ValidValue = string | string[], ExplicitType = SingleOrMultipleType> = ClassValueProp &
+  Omit<_ToggleGroupRootProps<ValidValue, ExplicitType>, 'as' | 'asChild'> & {
+    size?: ThemeSize;
+  };
 
-export type ToggleGroupItemProps = $ToggleGroupItemProps & {
-  class?: ClassValue;
-  variant?: ToggleVariant;
-  size?: ThemeSize;
-};
+export type ToggleGroupItemProps = ClassValueProp &
+  Omit<_ToggleGroupItemProps, 'as' | 'asChild'> & {
+    variant?: ToggleVariant;
+    size?: ThemeSize;
+  };
 
 export type ToggleGroupItemData = Pick<ToggleGroupItemProps, 'value' | 'disabled'>;
 
@@ -25,9 +22,13 @@ export type ToggleGroupProps<
   T extends ToggleGroupItemData = ToggleGroupItemData,
   ValidValue = string | string[],
   ExplicitType = SingleOrMultipleType
-> = $ToggleGroupRootProps<ValidValue, ExplicitType> & {
+> = ToggleGroupRootProps<ValidValue, ExplicitType> & {
   items: T[];
-  class?: ClassValue;
   variant?: ToggleVariant;
-  size?: ThemeSize;
 };
+
+export type ToggleGroupRootEmits<ValidValue = string | string[]> = {
+  'update:modelValue': [payload: ValidValue];
+};
+
+export type ToggleGroupEmits<ValidValue = string | string[]> = ToggleGroupRootEmits<ValidValue>;

--- a/packages/ui/src/components/toggle/toggle.vue
+++ b/packages/ui/src/components/toggle/toggle.vue
@@ -1,32 +1,28 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { Toggle, useForwardPropsEmits } from 'radix-vue';
-import type { ToggleEmits } from 'radix-vue';
 import { cn, toggleVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
-import type { ToggleProps } from './types';
+import type { ToggleEmits, ToggleProps } from './types';
 
 defineOptions({
   name: 'SToggle'
 });
 
-const props = defineProps<ToggleProps>();
+const { class: cls, variant, size, ...delegatedProps } = defineProps<ToggleProps>();
 
 const emit = defineEmits<ToggleEmits>();
 
-const delegatedProps = computedOmit(props, ['class', 'variant', 'size']);
-
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 
-const cls = computed(() => {
-  const { toggle } = toggleVariants({ variant: props.variant, size: props.size });
+const mergedCls = computed(() => {
+  const { toggle } = toggleVariants({ variant, size });
 
-  return cn(toggle(), props.class);
+  return cn(toggle(), cls);
 });
 </script>
 
 <template>
-  <Toggle v-bind="forwarded" :class="cls">
+  <Toggle v-bind="forwarded" :class="mergedCls">
     <slot />
   </Toggle>
 </template>

--- a/packages/ui/src/components/toggle/types.ts
+++ b/packages/ui/src/components/toggle/types.ts
@@ -1,11 +1,11 @@
-import type { ToggleProps as $ToggleProps } from 'radix-vue';
+import type { ToggleEmits, ToggleProps as _ToggleProps } from 'radix-vue';
 import type { ThemeSize, ToggleVariant } from '@soybean-ui/variants';
-import type { ClassValue } from '../../types';
+import type { ClassValueProp } from '../../types';
 
-export type ToggleProps = $ToggleProps & {
-  class?: ClassValue;
-  variant?: ToggleVariant;
-  size?: ThemeSize;
-};
+export type ToggleProps = ClassValueProp &
+  Omit<_ToggleProps, 'as' | 'asChild'> & {
+    variant?: ToggleVariant;
+    size?: ThemeSize;
+  };
 
-export type { ToggleVariant };
+export type { ToggleEmits, ToggleVariant };

--- a/packages/ui/src/components/tooltip/tooltip-arrow.vue
+++ b/packages/ui/src/components/tooltip/tooltip-arrow.vue
@@ -1,25 +1,23 @@
 <script setup lang="ts">
-import { TooltipArrow, useForwardProps } from 'radix-vue';
+import { computed } from 'vue';
+import { TooltipArrow } from 'radix-vue';
 import { cn, tooltipVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
 import type { TooltipArrowProps } from './types';
 
 defineOptions({
   name: 'STooltipArrow'
 });
 
-const props = defineProps<TooltipArrowProps>();
-
-const delegatedProps = computedOmit(props, ['class', 'asChild']);
-
-const forwardedProps = useForwardProps(delegatedProps);
+const { class: cls, width, height } = defineProps<TooltipArrowProps>();
 
 const { arrow } = tooltipVariants();
+
+const mergedCls = computed(() => cn(cls, arrow()));
 </script>
 
 <template>
-  <TooltipArrow as-child v-bind="forwardedProps">
-    <div :class="cn(arrow(), props.class)"></div>
+  <TooltipArrow as-child :width :height>
+    <div :class="mergedCls"></div>
   </TooltipArrow>
 </template>
 

--- a/packages/ui/src/components/tooltip/tooltip-content.vue
+++ b/packages/ui/src/components/tooltip/tooltip-content.vue
@@ -1,34 +1,26 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { TooltipContent, useForwardPropsEmits } from 'radix-vue';
-import type { TooltipContentEmits } from 'radix-vue';
 import { cn, tooltipVariants } from '@soybean-ui/variants';
-import { computedOmit } from '../../shared';
-import type { TooltipContentProps } from './types';
+import type { TooltipContentEmits, TooltipContentProps } from './types';
 
 defineOptions({
   name: 'STooltipContent'
 });
 
-const props = withDefaults(defineProps<TooltipContentProps>(), {
-  side: 'bottom',
-  sideOffset: 8,
-  align: 'center',
-  avoidCollisions: true,
-  collisionPadding: 0,
-  sticky: 'partial'
-});
+const { class: cls, sideOffset = 8, avoidCollisions = true, ...delegatedProps } = defineProps<TooltipContentProps>();
 
 const emit = defineEmits<TooltipContentEmits>();
-
-const delegatedProps = computedOmit(props, ['class']);
 
 const forwarded = useForwardPropsEmits(delegatedProps, emit);
 
 const { content } = tooltipVariants();
+
+const mergedCls = computed(() => cn(cls, content()));
 </script>
 
 <template>
-  <TooltipContent v-bind="forwarded" :class="cn(content(), props.class)">
+  <TooltipContent v-bind="forwarded" :class="mergedCls" :side-offset :avoid-collisions>
     <slot />
   </TooltipContent>
 </template>

--- a/packages/ui/src/components/tooltip/types.ts
+++ b/packages/ui/src/components/tooltip/types.ts
@@ -1,22 +1,20 @@
 import type {
-  TooltipArrowProps as $TooltipArrowProps,
-  TooltipContentProps as $TooltipContentProps,
+  TooltipContentEmits,
   TooltipPortalProps,
-  TooltipRootProps
+  TooltipRootEmits,
+  TooltipRootProps,
+  TooltipArrowProps as _TooltipArrowProps,
+  TooltipContentProps as _TooltipContentProps
 } from 'radix-vue';
-import type { ClassValue } from '../../types';
+import type { ClassValue, ClassValueProp } from '../../types';
 
-export type TooltipArrowProps = $TooltipArrowProps & {
-  class?: ClassValue;
-};
+export type TooltipArrowProps = ClassValueProp & Pick<_TooltipArrowProps, 'width' | 'height'>;
 
-export type TooltipContentProps = $TooltipContentProps & {
-  class?: ClassValue;
-};
+export type TooltipContentProps = ClassValueProp & Omit<_TooltipContentProps, 'as' | 'asChild'>;
 
 export type TooltipProps = TooltipRootProps &
   Pick<TooltipPortalProps, 'to'> &
-  Omit<TooltipContentProps, 'as' | 'asChild' | 'forceMount' | 'class'> & {
+  Omit<TooltipContentProps, 'class' | 'forceMount'> & {
     disabledPortal?: boolean;
     forceMountPortal?: boolean;
     contentClass?: ClassValue;
@@ -31,4 +29,6 @@ export type TooltipSide = NonNullable<TooltipContentProps['side']>;
 
 export type TooltipAlign = NonNullable<TooltipContentProps['align']>;
 
-export { TooltipPortalProps };
+export type TooltipEmits = TooltipRootEmits & TooltipContentEmits;
+
+export { TooltipPortalProps, TooltipRootEmits, TooltipContentEmits };

--- a/packages/ui/src/types/index.ts
+++ b/packages/ui/src/types/index.ts
@@ -3,6 +3,10 @@ export type { ThemeColor, ThemeOrientation, ThemeSize, ThemeAlign } from '@soybe
 
 export type ClassValue = string | null | undefined | Record<string, boolean> | ClassValue[];
 
+export type ClassValueProp = {
+  class?: ClassValue;
+};
+
 export type SingleOrMultipleType = 'single' | 'multiple';
 
 export type StringOrNumber = string | number;


### PR DESCRIPTION
1. `defineProps` deconstruction
2. property binding shorthand
3. merged classes: computed by computed, variations are executed inside or outside computed depending on whether they need to pass in variables or not.
4. Emits are uniformly written in types, and component key types are exported from types.
5. Component properties are eliminated from `Primitive` properties, and displayed properties are picked from `radix-vue`.
