### PR TITLE
optimize(packages): ui: optimize textarea.

### DIFF
--- a/packages/ui-variants/src/variants/textarea.ts
+++ b/packages/ui-variants/src/variants/textarea.ts
@@ -4,7 +4,7 @@ import type { VariantProps } from 'tailwind-variants';
 
 export const textareaVariants = tv({
   slots: {
-    root: 'relative',
+    root: 'relative overflow-hidden',
     content: [
       `flex w-full rounded-md border border-input bg-background`,
       `focus-visible:(outline-none ring-2 ring-offset-2 ring-offset-background ring-primary) disabled:(cursor-not-allowed opacity-50)`
@@ -14,27 +14,27 @@ export const textareaVariants = tv({
   variants: {
     size: {
       xs: {
-        content: 'px-1.5 py-0.75 text-xs',
+        content: 'px-1.5 py-0.75 text-xs min-h-6',
         count: 'text-xs'
       },
       sm: {
-        content: 'px-2 py-0.75 text-sm',
+        content: 'px-2 py-0.75 text-sm min-h-7',
         count: 'text-sm'
       },
       md: {
-        content: 'px-2.5 py-1.25 text-sm',
+        content: 'px-2.5 py-1.25 text-sm min-h-8',
         count: 'text-sm'
       },
       lg: {
-        content: 'px-3 py-1.25 text-base',
+        content: 'px-3 py-1.25 text-base min-h-9',
         count: 'text-base'
       },
       xl: {
-        content: 'px-3.5 py-1.75 text-base',
+        content: 'px-3.5 py-1.75 text-base min-h-10',
         count: 'text-base'
       },
       xxl: {
-        content: 'px-4 py-2.25 text-lg',
+        content: 'px-4 py-2.25 text-lg min-h-12',
         count: 'text-lg'
       }
     },


### PR DESCRIPTION
1. 给组件的root层添加overflow-hidden，避免插槽自定义显示内容超出min-h限定的高度时，插槽内容超出Textarea范围
2. 给对应的size添加min-h为对应的一行文本高度

<img width="660" alt="image" src="https://github.com/user-attachments/assets/943b1f99-07a7-4d13-81e3-32d8c4007770" />
