### PR TITLE
docs(projects): header support language switch

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -40,6 +40,18 @@ export default defineConfigWithTheme<CustomThemeConfig>({
       md.use(ComponentPreview);
     }
   },
+  locales: {
+    root: {
+      label: 'English',
+      lang: 'en-US',
+      link: '/'
+    },
+    zh: {
+      label: '简体中文',
+      lang: 'zh-CN',
+      link: '/zh'
+    }
+  },
   themeConfig: {
     logo: '/logo.svg',
     socialLinks: [{ icon: 'github', link: 'https://github.com/soybeanjs/soybean-ui' }],

--- a/docs/.vitepress/theme/layout/components/language-switch.vue
+++ b/docs/.vitepress/theme/layout/components/language-switch.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { useData, useRouter } from 'vitepress';
+import { computed } from 'vue';
+import { SDropdownMenu } from 'soy-ui';
+import { Icon } from '@iconify/vue';
+defineOptions({
+  name: 'LanguageSwitch'
+});
+
+const { site, lang } = useData();
+const locales = computed(() => site.value.locales);
+const { route, go } = useRouter();
+
+// get all language items
+const languageItems = computed(() => {
+  return Object.entries(locales.value).map(([key, value]) => ({
+    label: value.label,
+    value: key
+  }));
+});
+
+/** get current language label */
+function getCurrentLangLabel() {
+  for (const [_key, locale] of Object.entries(locales.value)) {
+    if (locale.lang === lang.value) {
+      return locale.label;
+    }
+  }
+  // default return first language label
+  return Object.values(locales.value)[0]?.label || 'English';
+}
+
+/** handle language switch */
+function handleChange(value: string) {
+  // get target language config
+  const targetLocale = locales.value[value];
+  if (!targetLocale) return;
+
+  // if target language is current language, do not redirect
+  if (targetLocale.lang === lang.value) return;
+
+  // get current path
+  let currentPath = route.path;
+
+  // remove current language prefix (if exists)
+  for (const locale of Object.values(locales.value)) {
+    if (locale.link && locale.link !== '/' && currentPath.startsWith(locale.link)) {
+      currentPath = currentPath.substring(locale.link.length) || '/';
+      break;
+    }
+  }
+
+  // if path is root path but not '/' , ensure it starts with '/'
+  if (currentPath !== '/' && !currentPath.startsWith('/')) {
+    currentPath = `/${currentPath}`;
+  }
+
+  // redirect to target language page
+  const targetPath =
+    targetLocale.link === '/' ? currentPath : `${targetLocale.link}${currentPath === '/' ? '' : currentPath}`;
+  go(targetPath);
+}
+</script>
+
+<template>
+  <SDropdownMenu :items="languageItems" :ui="{ content: 'min-w-20' }" @change="handleChange">
+    <template #trigger>
+      <div
+        class="mx-3 h-full inline-flex cursor-pointer items-center py-2 text-sm text-muted-foreground font-semibold hover:text-foreground"
+      >
+        <span class="whitespace-nowrap">{{ getCurrentLangLabel() }}</span>
+        <Icon icon="akar-icons:chevron-down" class="ml-2 text-sm" />
+      </div>
+    </template>
+    <template #item="item">
+      <div
+        class="flex-y-center cursor-pointer"
+        :class="{ 'cursor-not-allowed': item.label === getCurrentLangLabel() }"
+        @click="handleChange(item.value)"
+      >
+        <span>{{ item.label }}</span>
+        <Icon v-if="item.label !== getCurrentLangLabel()" icon="lucide:arrow-up-right" class="ml-2 text-sm" />
+      </div>
+    </template>
+  </SDropdownMenu>
+</template>

--- a/docs/.vitepress/theme/layout/components/navbar.vue
+++ b/docs/.vitepress/theme/layout/components/navbar.vue
@@ -6,6 +6,7 @@ import { SButtonIcon, SDropdownMenu, SPopover, SSeparator } from 'soy-ui';
 import { Icon } from '@iconify/vue';
 import type { CustomThemeConfig, NavItem as NavItemType } from '../../../types';
 import ThemeToggle from './theme-toggle.vue';
+import LanguageSwitch from './language-switch.vue';
 
 defineOptions({
   name: 'Navbar'
@@ -75,6 +76,7 @@ watch(path, () => {
         </template>
       </SDropdownMenu>
     </template>
+    <LanguageSwitch />
     <SSeparator class="mx-4 h-4" decorative orientation="vertical" />
     <slot name="theme-customize" />
     <ThemeToggle />

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -1,0 +1,3 @@
+---
+layout: home
+title: Soybean UI - 一个类似于shadcn的优雅且易用的Vue3 UI库


### PR DESCRIPTION
尝试支持了一下header的语言切换，第一次写vitepress的组件，不知是否可以这样实现，部分效果（item的disable之类）在当前的SDropdownMenu貌似没有支持，后续更新组件后可以继续优化，主要实现了对locales配置的自适应支持，跳转对应语言的对应页面